### PR TITLE
PR: Add ChatClient (XEP-0085 / 0184 / 0333 / 0308)

### DIFF
--- a/Networking/Waher.Networking.XMPP.Test/XmppChatMarkerTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/XmppChatMarkerTests.cs
@@ -1,0 +1,342 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Waher.Events;
+using Waher.Networking.Sniffers;
+using Waher.Networking.Sniffers.Model;
+using Waher.Networking.XMPP.Chat;
+using Waher.Networking.XMPP.Chat.Markers;
+using Waher.Networking.XMPP.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Waher.Networking.XMPP.Test
+{
+	[TestClass]
+	public class XmppChatMarkerTests : CommunicationTests
+	{
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext _)
+		{
+			SetupSnifferAndLog();
+		}
+
+		[ClassCleanup]
+		public static async Task ClassCleanup()
+		{
+			await DisposeSnifferAndLog();
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_01_MarkableInbound()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatMarkers = true;
+
+			using ManualResetEvent markerReceived = new ManualResetEvent(false);
+			string markerId = string.Empty;
+			ChatMarkerType markerType = ChatMarkerType.Markable;
+
+			EventHandlerAsync<ChatMarkerEventArgs> markerHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID)
+				{
+					markerType = e.MarkerType;
+					markerId = e.Id;
+					markerReceived.Set();
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatMarker += markerHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat' id='m1'>" +
+					"<body>Markable</body>" +
+					"<markable xmlns='urn:xmpp:chat-markers:0'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(markerReceived.WaitOne(1000), "Markable marker not received.");
+				Assert.AreEqual(ChatMarkerType.Markable, markerType, "Marker type mismatch.");
+				Assert.AreEqual("m1", markerId, "Marker id mismatch.");
+			}
+			finally
+			{
+				chatClient2.OnChatMarker -= markerHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_02_DisplayedInbound()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatMarkers = true;
+
+			using ManualResetEvent markerReceived = new ManualResetEvent(false);
+			string markerId = string.Empty;
+			ChatMarkerType markerType = ChatMarkerType.Markable;
+
+			EventHandlerAsync<ChatMarkerEventArgs> markerHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID)
+				{
+					markerType = e.MarkerType;
+					markerId = e.Id;
+					markerReceived.Set();
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatMarker += markerHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat'>" +
+					"<displayed xmlns='urn:xmpp:chat-markers:0' id='orig1'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(markerReceived.WaitOne(1000), "Displayed marker not received.");
+				Assert.AreEqual(ChatMarkerType.Displayed, markerType, "Marker type mismatch.");
+				Assert.AreEqual("orig1", markerId, "Marker id mismatch.");
+			}
+			finally
+			{
+				chatClient2.OnChatMarker -= markerHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_03_GroupChatDoesNotAutoDisplay()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatMarkers = true;
+			chatClient2.AutoSendDisplayedMarkers = true;
+
+			using ManualResetEvent markerReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<ChatMarkerEventArgs> markerHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID)
+					markerReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Marker-Groupchat-Sniffer");
+			this.client2.Add(sniffer);
+
+			chatClient2.OnChatMarker += markerHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='groupchat' id='gm1'>" +
+					"<body>Group markable</body>" +
+					"<markable xmlns='urn:xmpp:chat-markers:0'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(markerReceived.WaitOne(1000), "Groupchat markable marker not received.");
+
+				bool displayedSent = false;
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is SnifferTxText tx &&
+						tx.Text.Contains("<displayed") &&
+						tx.Text.Contains("urn:xmpp:chat-markers:0"))
+					{
+						displayedSent = true;
+						break;
+					}
+				}
+
+				Assert.IsFalse(displayedSent, "Displayed marker should not be auto-sent for groupchat.");
+			}
+			finally
+			{
+				chatClient2.OnChatMarker -= markerHandler;
+				this.client2.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_04_OutboundMarkersSent()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			chatClient1.EnableChatMarkers = true;
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Marker-Outbound-Sniffer");
+			this.client1.Add(sniffer);
+
+			try
+			{
+				await chatClient1.SendMarkable(this.client2.BareJID, "mk1");
+				await chatClient1.SendDisplayedMarker(this.client2.BareJID, "mk1");
+				await Task.Delay(250);
+
+				bool markableSent = false;
+				bool displayedSent = false;
+
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is SnifferTxText tx && tx.Text.Contains("urn:xmpp:chat-markers:0"))
+					{
+						if (tx.Text.Contains("<markable") && tx.Text.Contains("id='mk1'"))
+							markableSent = true;
+						else if (tx.Text.Contains("<displayed") && tx.Text.Contains("id='mk1'"))
+							displayedSent = true;
+					}
+				}
+
+				Assert.IsTrue(markableSent, "Markable marker not sent.");
+				Assert.IsTrue(displayedSent, "Displayed marker not sent.");
+			}
+			finally
+			{
+				this.client1.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient1.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_05_MarkerOnlyDoesNotTriggerChatMessage()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatMarkers = true;
+
+			using ManualResetEvent markerReceived = new ManualResetEvent(false);
+			using ManualResetEvent chatMessageReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<ChatMarkerEventArgs> markerHandler = (sender, e) =>
+			{
+				markerReceived.Set();
+				return Task.CompletedTask;
+			};
+
+			EventHandlerAsync<MessageEventArgs> chatHandler = (sender, e) =>
+			{
+				chatMessageReceived.Set();
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatMarker += markerHandler;
+			this.client2.OnChatMessage += chatHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat' id='m2'>" +
+					"<markable xmlns='urn:xmpp:chat-markers:0'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(markerReceived.WaitOne(1000), "Marker event was not raised.");
+				Assert.IsFalse(chatMessageReceived.WaitOne(500), "Marker-only stanza should not trigger chat message handlers.");
+			}
+			finally
+			{
+				chatClient2.OnChatMarker -= markerHandler;
+				this.client2.OnChatMessage -= chatHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatMarkers_Test_06_DisplayedDoesNotAutoSend()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatMarkers = true;
+			chatClient2.AutoSendDisplayedMarkers = true;
+
+			using ManualResetEvent markerReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<ChatMarkerEventArgs> markerHandler = (sender, e) =>
+			{
+				if (e.MarkerType == ChatMarkerType.Displayed)
+					markerReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Marker-Displayed-Sniffer");
+			this.client2.Add(sniffer);
+
+			chatClient2.OnChatMarker += markerHandler;
+
+			try
+			{
+				int baseline = sniffer.ToArray().Length;
+
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat'>" +
+					"<displayed xmlns='urn:xmpp:chat-markers:0' id='orig2'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(markerReceived.WaitOne(1000), "Displayed marker not received.");
+
+				SnifferEvent[] events = sniffer.ToArray();
+				bool displayedSent = false;
+
+				for (int i = baseline; i < events.Length; i++)
+				{
+					if (events[i] is SnifferTxText tx &&
+						tx.Text.Contains("<displayed") &&
+						tx.Text.Contains("urn:xmpp:chat-markers:0"))
+					{
+						displayedSent = true;
+						break;
+					}
+				}
+
+				Assert.IsFalse(displayedSent, "Displayed marker should not be auto-sent in response to displayed.");
+			}
+			finally
+			{
+				chatClient2.OnChatMarker -= markerHandler;
+				this.client2.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP.Test/XmppChatStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/XmppChatStateTests.cs
@@ -1,0 +1,735 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Reflection;
+using Waher.Networking.XMPP.Events;
+using Waher.Networking.Sniffers;
+using Waher.Networking.Sniffers.Model;
+using Waher.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Waher.Networking.XMPP.Chat;
+using Waher.Networking.XMPP.Chat.ChatStates;
+
+namespace Waher.Networking.XMPP.Test
+{
+	[TestClass]
+	public class XmppChatStateTests : CommunicationTests
+	{
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext _)
+		{
+			SetupSnifferAndLog();
+		}
+
+		[ClassCleanup]
+		public static async Task ClassCleanup()
+		{
+			await DisposeSnifferAndLog();
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_01_ImplicitNegotiation()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			Assert.IsFalse(chatClient1.EnableChatStateNotifications, "Client 1 should disable chat state notifications by default.");
+			Assert.IsFalse(chatClient2.EnableChatStateNotifications, "Client 2 should disable chat state notifications by default.");
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent client2Active = new ManualResetEvent(false);
+			using ManualResetEvent client1Active = new ManualResetEvent(false);
+			using ManualResetEvent client1Supported = new ManualResetEvent(false);
+			using ManualResetEvent client2Supported = new ManualResetEvent(false);
+
+			ChatStateSupportDeterminedEventHandler client1SupportHandler = (bareJid, supported) =>
+			{
+				if (supported && bareJid == this.client2.BareJID)
+					client1Supported.Set();
+
+				return Task.CompletedTask;
+			};
+
+			ChatStateSupportDeterminedEventHandler client2SupportHandler = (bareJid, supported) =>
+			{
+				if (supported && bareJid == this.client1.BareJID)
+					client2Supported.Set();
+
+				return Task.CompletedTask;
+			};
+
+			int responseSent = 0;
+
+			EventHandlerAsync<ChatStateEventArgs> client2StateHandler = async (sender, e) =>
+			{
+				if (e.State == ChatState.Active && e.Message.FromBareJID == this.client1.BareJID)
+				{
+					client2Active.Set();
+
+					if (Interlocked.Exchange(ref responseSent, 1) == 0)
+						await chatClient2.SendChatContentMessage(this.client1.BareJID, "Hello back!", string.Empty, string.Empty, string.Empty, string.Empty);
+				}
+			};
+
+			EventHandlerAsync<ChatStateEventArgs> client1StateHandler = (sender, e) =>
+			{
+				if (e.State == ChatState.Active && e.Message.FromBareJID == this.client2.BareJID)
+					client1Active.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnChatStateSupportDetermined += client1SupportHandler;
+			chatClient2.OnChatStateSupportDetermined += client2SupportHandler;
+			chatClient2.OnChatStateChanged += client2StateHandler;
+			chatClient1.OnChatStateChanged += client1StateHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Hello there!", string.Empty, string.Empty, string.Empty, string.Empty);
+
+				Assert.IsTrue(client2Active.WaitOne(10000), "Client 2 did not observe the active chat state.");
+				Assert.IsTrue(client2Supported.WaitOne(10000), "Client 2 did not resolve chat state support.");
+				Assert.IsTrue(client1Supported.WaitOne(10000), "Client 1 did not resolve chat state support.");
+				Assert.IsTrue(client1Active.WaitOne(10000), "Client 1 did not observe the active chat state reply.");
+			}
+			finally
+			{
+				chatClient1.OnChatStateSupportDetermined -= client1SupportHandler;
+				chatClient2.OnChatStateSupportDetermined -= client2SupportHandler;
+				chatClient2.OnChatStateChanged -= client2StateHandler;
+				chatClient1.OnChatStateChanged -= client1StateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_02_NegotiationFailure()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = false;
+
+			using ManualResetEvent notSupported = new ManualResetEvent(false);
+			using ManualResetEvent stateReceived = new ManualResetEvent(false);
+
+			int responseSent = 0;
+
+			ChatStateSupportDeterminedEventHandler client1SupportHandler = (bareJid, supported) =>
+			{
+				if (bareJid == this.client2.BareJID && !supported)
+					notSupported.Set();
+
+				return Task.CompletedTask;
+			};
+
+			EventHandlerAsync<ChatStateEventArgs> client2NegotiationHandler = async (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID &&
+					e.State == ChatState.Active &&
+					Interlocked.Exchange(ref responseSent, 1) == 0)
+				{
+					await this.client2.SendMessage(MessageType.Chat, this.client1.BareJID, string.Empty, "Notifications disabled.", string.Empty, string.Empty, string.Empty, string.Empty);
+				}
+			};
+
+			EventHandlerAsync<ChatStateEventArgs> client2StateHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID)
+					stateReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnChatStateSupportDetermined += client1SupportHandler;
+			chatClient2.OnChatStateChanged += client2NegotiationHandler;
+			chatClient2.OnChatStateChanged += client2StateHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Testing negotiation.", string.Empty, string.Empty, string.Empty, string.Empty);
+
+				Assert.IsTrue(notSupported.WaitOne(10000), "Client 1 did not detect lack of chat state support.");
+				Assert.IsFalse(chatClient1.IsChatStateSupported(this.client2.BareJID), "Client 1 should mark contact as not supporting chat states.");
+
+				stateReceived.Reset();
+				await chatClient1.SendChatState(this.client2.BareJID, ChatState.Composing);
+
+				Assert.IsFalse(stateReceived.WaitOne(1000), "Standalone state should be suppressed after negotiation failure.");
+			}
+			finally
+			{
+				chatClient1.OnChatStateSupportDetermined -= client1SupportHandler;
+				chatClient2.OnChatStateChanged -= client2NegotiationHandler;
+				chatClient2.OnChatStateChanged -= client2StateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_03_ThreadRollsAfterGone()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent firstMessage = new ManualResetEvent(false);
+			using ManualResetEvent goneReceived = new ManualResetEvent(false);
+			using ManualResetEvent duplicateGoneReceived = new ManualResetEvent(false);
+			using ManualResetEvent secondMessage = new ManualResetEvent(false);
+
+			string initialThreadId = string.Empty;
+			string newThreadId = string.Empty;
+			int messageCount = 0;
+			int goneCount = 0;
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID != this.client1.BareJID)
+					return Task.CompletedTask;
+
+				if (e.State == ChatState.Gone)
+				{
+					if (Interlocked.Increment(ref goneCount) == 1)
+						goneReceived.Set();
+					else
+						duplicateGoneReceived.Set();
+				}
+				else if (e.State == ChatState.Active)
+				{
+					MessageEventArgs msg = e.Message;
+					int count = Interlocked.Increment(ref messageCount);
+
+					if (count == 1)
+					{
+						initialThreadId = msg.ThreadID;
+						firstMessage.Set();
+					}
+					else if (count == 2)
+					{
+						newThreadId = msg.ThreadID;
+						secondMessage.Set();
+					}
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Start thread", string.Empty, string.Empty, "initial-thread", string.Empty);
+
+				Assert.IsTrue(firstMessage.WaitOne(10000), "Initial thread message not received.");
+				Assert.AreEqual("initial-thread", initialThreadId, "Initial thread identifier mismatch.");
+
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Gone, MessageType.Chat, "initial-thread");
+				Assert.IsTrue(goneReceived.WaitOne(10000), "Gone state was not received.");
+
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Gone, MessageType.Chat, "initial-thread");
+				Assert.IsFalse(duplicateGoneReceived.WaitOne(1000), "Gone state should be one-shot per thread.");
+
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Follow-up message", string.Empty, string.Empty, string.Empty, string.Empty);
+
+				Assert.IsTrue(secondMessage.WaitOne(10000), "Follow-up message not received.");
+				Assert.IsFalse(string.IsNullOrEmpty(newThreadId), "New message should generate a thread identifier.");
+				Assert.AreNotEqual(initialThreadId, newThreadId, "Thread identifier should change after gone state.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_04_GroupChatGoneSuppressed()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent stateReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID && e.State == ChatState.Gone)
+					stateReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				Task send = chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Gone, MessageType.GroupChat);
+
+				Assert.IsNotNull(send);
+				Assert.IsTrue(send.IsCompleted, "Groupchat gone should be suppressed immediately.");
+				Assert.IsFalse(stateReceived.WaitOne(1000), "Gone state must not be delivered in groupchat context.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_05_IncomingGroupChatGoneIgnored()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent goneReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID == this.client1.BareJID && e.State == ChatState.Gone)
+					goneReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='groupchat'>" +
+					"<gone xmlns='http://jabber.org/protocol/chatstates'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsFalse(goneReceived.WaitOne(1000), "Incoming groupchat gone should be ignored.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_06_DuplicateStandaloneSuppression()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent composingReceived = new ManualResetEvent(false);
+			using ManualResetEvent pausedReceived = new ManualResetEvent(false);
+			using ManualResetEvent inactiveReceived = new ManualResetEvent(false);
+			using ManualResetEvent goneReceived = new ManualResetEvent(false);
+
+			int composingCount = 0;
+			int pausedCount = 0;
+			int inactiveCount = 0;
+			int goneCount = 0;
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.Message.FromBareJID != this.client1.BareJID)
+					return Task.CompletedTask;
+
+				switch (e.State)
+				{
+					case ChatState.Composing:
+						if (Interlocked.Increment(ref composingCount) == 1)
+							composingReceived.Set();
+						break;
+
+					case ChatState.Paused:
+						if (Interlocked.Increment(ref pausedCount) == 1)
+							pausedReceived.Set();
+						break;
+
+					case ChatState.Inactive:
+						if (Interlocked.Increment(ref inactiveCount) == 1)
+							inactiveReceived.Set();
+						break;
+
+					case ChatState.Gone:
+						if (Interlocked.Increment(ref goneCount) == 1)
+							goneReceived.Set();
+						break;
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Composing, MessageType.Chat, "dup-thread-composing");
+				Assert.IsTrue(composingReceived.WaitOne(10000), "Composing state not received.");
+				composingReceived.Reset();
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Composing, MessageType.Chat, "dup-thread-composing");
+				Assert.IsFalse(composingReceived.WaitOne(1000), "Duplicate composing state should be suppressed.");
+
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Paused, MessageType.Chat, "dup-thread-paused");
+				Assert.IsTrue(pausedReceived.WaitOne(10000), "Paused state not received.");
+				pausedReceived.Reset();
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Paused, MessageType.Chat, "dup-thread-paused");
+				Assert.IsFalse(pausedReceived.WaitOne(1000), "Duplicate paused state should be suppressed.");
+
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Inactive, MessageType.Chat, "dup-thread-inactive");
+				Assert.IsTrue(inactiveReceived.WaitOne(10000), "Inactive state not received.");
+				inactiveReceived.Reset();
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Inactive, MessageType.Chat, "dup-thread-inactive");
+				Assert.IsFalse(inactiveReceived.WaitOne(1000), "Duplicate inactive state should be suppressed.");
+
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Gone, MessageType.Chat, "dup-thread-gone");
+				Assert.IsTrue(goneReceived.WaitOne(10000), "Gone state not received.");
+				goneReceived.Reset();
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Gone, MessageType.Chat, "dup-thread-gone");
+				Assert.IsFalse(goneReceived.WaitOne(1000), "Duplicate gone state should be suppressed.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_07_ThreadPropagationOnStandalone()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent composingReceived = new ManualResetEvent(false);
+			string composingThreadId = string.Empty;
+
+			EventHandlerAsync<MessageEventArgs> composingHandler = (sender, e) =>
+			{
+				if (e.FromBareJID == this.client1.BareJID)
+				{
+					composingThreadId = e.ThreadID;
+					composingReceived.Set();
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatComposing += composingHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Thread seed", string.Empty, string.Empty, "thread-propagation", string.Empty);
+				await chatClient1.SendComposing(this.client2.BareJID);
+
+				Assert.IsTrue(composingReceived.WaitOne(10000), "Composing state not received.");
+				Assert.AreEqual("thread-propagation", composingThreadId, "Standalone chat state should reuse the current thread.");
+			}
+			finally
+			{
+				chatClient2.OnChatComposing -= composingHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_08_ActiveEmbeddedOnlyInContentMessages()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent activeReceived = new ManualResetEvent(false);
+			int activeCount = 0;
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.State == ChatState.Active && e.Message.FromBareJID == this.client1.BareJID)
+				{
+					Interlocked.Increment(ref activeCount);
+					activeReceived.Set();
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, string.Empty, "Subject-only", string.Empty, string.Empty, string.Empty);
+				Assert.IsTrue(activeReceived.WaitOne(10000), "Active state should be embedded when subject is present.");
+
+				activeReceived.Reset();
+				int activeBefore = activeCount;
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
+				Assert.IsFalse(activeReceived.WaitOne(1000), "Active state should not be embedded for empty content.");
+				Assert.AreEqual(activeBefore, activeCount, "Active state should not be emitted for empty content.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_09_NonChatStateMessageDoesNotMarkNotSupported()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent notSupported = new ManualResetEvent(false);
+			bool messageSent = false;
+
+			ChatStateSupportDeterminedEventHandler supportHandler = (bareJid, supported) =>
+			{
+				if (messageSent && bareJid == this.client2.BareJID && !supported)
+					notSupported.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnChatStateSupportDetermined += supportHandler;
+
+			try
+			{
+				messageSent = true;
+				await this.client2.SendMessage(MessageType.Chat, this.client1.BareJID, string.Empty, "Plain message", string.Empty, string.Empty, string.Empty, string.Empty);
+				Assert.IsFalse(notSupported.WaitOne(1000), "Non-chatstate message should not mark contact as not supported unless requested.");
+			}
+			finally
+			{
+				chatClient1.OnChatStateSupportDetermined -= supportHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_10_EnableDisableTogglesEmbedding()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent activeReceived = new ManualResetEvent(false);
+			int activeCount = 0;
+
+			EventHandlerAsync<ChatStateEventArgs> stateHandler = (sender, e) =>
+			{
+				if (e.State == ChatState.Active && e.Message.FromBareJID == this.client1.BareJID)
+				{
+					Interlocked.Increment(ref activeCount);
+					activeReceived.Set();
+				}
+
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnChatStateChanged += stateHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Active on", string.Empty, string.Empty, string.Empty, string.Empty);
+				Assert.IsTrue(activeReceived.WaitOne(10000), "Active state should be embedded when enabled.");
+
+				chatClient1.EnableChatStateNotifications = false;
+				activeReceived.Reset();
+				int before = activeCount;
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Active off", string.Empty, string.Empty, string.Empty, string.Empty);
+				Assert.IsFalse(activeReceived.WaitOne(1000), "Active state should not be embedded when disabled.");
+				Assert.AreEqual(before, activeCount, "Active state should not be emitted when disabled.");
+
+				chatClient1.EnableChatStateNotifications = true;
+				activeReceived.Reset();
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Active on again", string.Empty, string.Empty, string.Empty, string.Empty);
+				Assert.IsTrue(activeReceived.WaitOne(10000), "Active state should be embedded again after re-enable.");
+			}
+			finally
+			{
+				chatClient2.OnChatStateChanged -= stateHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_11_GroupChatComposingIsSent()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			chatClient1.EnableChatStateNotifications = true;
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "ChatState-Send-Sniffer");
+			this.client1.Add(sniffer);
+
+			try
+			{
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Composing, MessageType.GroupChat);
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Paused, MessageType.GroupChat);
+				await chatClient1.SendStandaloneChatState(this.client2.BareJID, ChatState.Inactive, MessageType.GroupChat);
+				await Task.Delay(250);
+
+				bool foundComposing = false;
+				bool foundPaused = false;
+				bool foundInactive = false;
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is SnifferTxText tx &&
+						tx.Text.Contains("type='groupchat'") &&
+						tx.Text.Contains("http://jabber.org/protocol/chatstates"))
+					{
+						if (tx.Text.Contains("<composing"))
+							foundComposing = true;
+						else if (tx.Text.Contains("<paused"))
+							foundPaused = true;
+						else if (tx.Text.Contains("<inactive"))
+							foundInactive = true;
+					}
+				}
+
+				Assert.IsTrue(foundComposing, "Groupchat composing state should be sent.");
+				Assert.IsTrue(foundPaused, "Groupchat paused state should be sent.");
+				Assert.IsTrue(foundInactive, "Groupchat inactive state should be sent.");
+			}
+			finally
+			{
+				this.client1.Remove(sniffer);
+				await sniffer.DisposeAsync();
+				chatClient1.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task ChatStates_Test_12_ResetStateClearsNegotiationAndThreadTracking()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableChatStateNotifications = true;
+			chatClient2.EnableChatStateNotifications = true;
+
+			using ManualResetEvent supportedReceived = new ManualResetEvent(false);
+
+			ChatStateSupportDeterminedEventHandler supportHandler = (bareJid, supported) =>
+			{
+				if (supported && bareJid == this.client2.BareJID)
+					supportedReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnChatStateSupportDetermined += supportHandler;
+
+			try
+			{
+				await chatClient1.SendChatContentMessage(this.client2.BareJID, "Seed thread", string.Empty, string.Empty, "reset-thread", string.Empty);
+				await chatClient2.SendComposing(this.client1.BareJID);
+
+				Assert.IsTrue(supportedReceived.WaitOne(10000), "Chat state support not detected before reset.");
+
+				int negotiationCountBefore = GetPrivateCollectionCount(chatClient1, "chatStateNegotiation");
+				int threadCountBefore = GetPrivateCollectionCount(chatClient1, "currentThreadIdPerContact");
+
+				Assert.IsTrue(negotiationCountBefore > 0, "Negotiation state should be tracked before reset.");
+				Assert.IsTrue(threadCountBefore > 0, "Thread tracking should be populated before reset.");
+
+				MethodInfo stateChanged = typeof(ChatClient).GetMethod("Client_OnStateChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+				Assert.IsNotNull(stateChanged, "Client_OnStateChanged handler not found.");
+
+				Task stateTask = (Task)stateChanged.Invoke(chatClient1, new object[] { this.client1, XmppState.Offline });
+				if (stateTask != null)
+					await stateTask;
+
+				int negotiationCountAfter = GetPrivateCollectionCount(chatClient1, "chatStateNegotiation");
+				int threadCountAfter = GetPrivateCollectionCount(chatClient1, "currentThreadIdPerContact");
+
+				Assert.AreEqual(0, negotiationCountAfter, "Negotiation state should be cleared on offline.");
+				Assert.AreEqual(0, threadCountAfter, "Thread tracking should be cleared on offline.");
+			}
+			finally
+			{
+				chatClient1.OnChatStateSupportDetermined -= supportHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+
+			static int GetPrivateCollectionCount(ChatClient client, string fieldName)
+			{
+				FieldInfo field = typeof(ChatClient).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+				Assert.IsNotNull(field, "Field not found: " + fieldName);
+
+				object value = field.GetValue(client);
+				PropertyInfo countProperty = value?.GetType().GetProperty("Count");
+				Assert.IsNotNull(countProperty, "Count property not found: " + fieldName);
+
+				return (int)countProperty.GetValue(value);
+			}
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP.Test/XmppDeliveryReceiptTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/XmppDeliveryReceiptTests.cs
@@ -1,0 +1,331 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Waher.Events;
+using Waher.Networking.Sniffers;
+using Waher.Networking.Sniffers.Model;
+using Waher.Networking.XMPP.Chat;
+using Waher.Networking.XMPP.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Waher.Networking.XMPP.Test
+{
+	[TestClass]
+	public class XmppDeliveryReceiptTests : CommunicationTests
+	{
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext _)
+		{
+			SetupSnifferAndLog();
+		}
+
+		[ClassCleanup]
+		public static async Task ClassCleanup()
+		{
+			await DisposeSnifferAndLog();
+		}
+
+		[TestMethod]
+		public async Task DeliveryReceipts_Test_01_AutoAckRequest()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableDeliveryReceipts = true;
+			chatClient2.EnableDeliveryReceipts = true;
+			chatClient2.AutoRespondToReceiptRequests = true;
+
+			using ManualResetEvent receiptReceived = new ManualResetEvent(false);
+
+			string messageId = this.client1.NextId();
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> receivedHandler = (sender, e) =>
+			{
+				if (e.IsReceived && e.Id == messageId && e.Message.FromBareJID == this.client2.BareJID)
+					receiptReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnReceiptReceived += receivedHandler;
+
+			try
+			{
+				await chatClient1.SendChatMessageWithReceiptRequest(this.client2.BareJID, "Receipt please.", messageId);
+				Assert.IsTrue(receiptReceived.WaitOne(10000), "Receipt response was not received.");
+			}
+			finally
+			{
+				chatClient1.OnReceiptReceived -= receivedHandler;
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task DeliveryReceipts_Test_02_NoAckWithoutId()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableDeliveryReceipts = true;
+			chatClient2.AutoRespondToReceiptRequests = true;
+
+			using ManualResetEvent requestReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> requestHandler = (sender, e) =>
+			{
+				if (e.IsRequest)
+					requestReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Receipt-Ack-Sniffer");
+			this.client2.Add(sniffer);
+
+			chatClient2.OnReceiptRequest += requestHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat'>" +
+					"<body>No id.</body>" +
+					"<request xmlns='urn:xmpp:receipts'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(requestReceived.WaitOne(1000), "Receipt request event was not raised.");
+
+				bool ackSent = false;
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is SnifferTxText tx &&
+						tx.Text.Contains("<received") &&
+						tx.Text.Contains("urn:xmpp:receipts"))
+					{
+						ackSent = true;
+						break;
+					}
+				}
+
+				Assert.IsFalse(ackSent, "Auto-ack should not be sent without a stanza id.");
+			}
+			finally
+			{
+				chatClient2.OnReceiptRequest -= requestHandler;
+				this.client2.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task DeliveryReceipts_Test_03_NoAckForDelayedMessage()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableDeliveryReceipts = true;
+			chatClient2.AutoRespondToReceiptRequests = true;
+
+			using ManualResetEvent requestReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> requestHandler = (sender, e) =>
+			{
+				if (e.IsRequest)
+					requestReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Receipt-Delay-Sniffer");
+			this.client2.Add(sniffer);
+
+			chatClient2.OnReceiptRequest += requestHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat' id='d1'>" +
+					"<body>Delayed.</body>" +
+					"<delay xmlns='urn:xmpp:delay' stamp='2020-01-01T00:00:00Z'/>" +
+					"<request xmlns='urn:xmpp:receipts'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(requestReceived.WaitOne(1000), "Receipt request event was not raised.");
+
+				bool ackSent = false;
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is SnifferTxText tx &&
+						tx.Text.Contains("<received") &&
+						tx.Text.Contains("urn:xmpp:receipts"))
+					{
+						ackSent = true;
+						break;
+					}
+				}
+
+				Assert.IsFalse(ackSent, "Auto-ack should not be sent for delayed messages.");
+			}
+			finally
+			{
+				chatClient2.OnReceiptRequest -= requestHandler;
+				this.client2.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task DeliveryReceipts_Test_04_AckIsReceiptOnly()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			ChatClient chatClient2 = new ChatClient(this.client2);
+
+			chatClient1.EnableDeliveryReceipts = true;
+			chatClient2.EnableDeliveryReceipts = true;
+			chatClient2.AutoRespondToReceiptRequests = true;
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Receipt-Only-Sniffer");
+			this.client2.Add(sniffer);
+
+			using ManualResetEvent receiptReceived = new ManualResetEvent(false);
+
+			string messageId = this.client1.NextId();
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> receivedHandler = (sender, e) =>
+			{
+				if (e.IsReceived && e.Id == messageId)
+					receiptReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			chatClient1.OnReceiptReceived += receivedHandler;
+
+			try
+			{
+				await chatClient1.SendChatMessageWithReceiptRequest(this.client2.BareJID, "Receipt only ack.", messageId);
+				Assert.IsTrue(receiptReceived.WaitOne(10000), "Receipt response was not received.");
+
+				bool receiptOnly = false;
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is not SnifferTxText tx || !tx.Text.Contains("<message"))
+						continue;
+
+					try
+					{
+						XmlDocument doc = new XmlDocument();
+						doc.LoadXml(tx.Text);
+
+						if (doc.DocumentElement is null || doc.DocumentElement.LocalName != "message")
+							continue;
+
+						bool hasReceived = false;
+						bool hasRequest = false;
+						bool hasBody = false;
+						bool hasSubject = false;
+
+						foreach (XmlNode node in doc.DocumentElement.ChildNodes)
+						{
+							if (node is not XmlElement element)
+								continue;
+
+							if (element.LocalName == "received" && element.NamespaceURI == "urn:xmpp:receipts")
+								hasReceived = true;
+							else if (element.LocalName == "request" && element.NamespaceURI == "urn:xmpp:receipts")
+								hasRequest = true;
+							else if (element.LocalName == "body")
+								hasBody = true;
+							else if (element.LocalName == "subject")
+								hasSubject = true;
+						}
+
+						if (hasReceived)
+							receiptOnly = !hasRequest && !hasBody && !hasSubject;
+					}
+					catch (XmlException)
+					{
+						// Ignore non-stanza output
+					}
+				}
+
+				Assert.IsTrue(receiptOnly, "Receipt ack should not include request, body, or subject.");
+			}
+			finally
+			{
+				chatClient1.OnReceiptReceived -= receivedHandler;
+				this.client2.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient1.Dispose();
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task DeliveryReceipts_Test_05_ReceiptOnlyDoesNotTriggerChatMessage()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableDeliveryReceipts = true;
+
+			using ManualResetEvent receiptReceived = new ManualResetEvent(false);
+			using ManualResetEvent chatMessageReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> receivedHandler = (sender, e) =>
+			{
+				if (e.IsReceived && e.Id == "r1")
+					receiptReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			EventHandlerAsync<MessageEventArgs> chatHandler = (sender, e) =>
+			{
+				chatMessageReceived.Set();
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnReceiptReceived += receivedHandler;
+			this.client2.OnChatMessage += chatHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat'>" +
+					"<received xmlns='urn:xmpp:receipts' id='r1'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(receiptReceived.WaitOne(1000), "Receipt event was not raised.");
+				Assert.IsFalse(chatMessageReceived.WaitOne(500), "Receipt-only stanza should not trigger chat message handlers.");
+			}
+			finally
+			{
+				chatClient2.OnReceiptReceived -= receivedHandler;
+				this.client2.OnChatMessage -= chatHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP.Test/XmppMessageCorrectionTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/XmppMessageCorrectionTests.cs
@@ -1,0 +1,244 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Waher.Events;
+using Waher.Networking.Sniffers;
+using Waher.Networking.Sniffers.Model;
+using Waher.Networking.XMPP.Chat;
+using Waher.Networking.XMPP.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Waher.Networking.XMPP.Test
+{
+	[TestClass]
+	public class XmppMessageCorrectionTests : CommunicationTests
+	{
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext _)
+		{
+			SetupSnifferAndLog();
+		}
+
+		[ClassCleanup]
+		public static async Task ClassCleanup()
+		{
+			await DisposeSnifferAndLog();
+		}
+
+		[TestMethod]
+		public async Task MessageCorrection_Test_01_InboundReplace()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableMessageCorrection = true;
+
+			using ManualResetEvent correctionReceived = new ManualResetEvent(false);
+			string replaceId = string.Empty;
+			string newBody = string.Empty;
+			string newSubject = string.Empty;
+
+			EventHandlerAsync<MessageCorrectionEventArgs> correctionHandler = (sender, e) =>
+			{
+				replaceId = e.ReplaceId;
+				newBody = e.NewBody;
+				newSubject = e.NewSubject;
+				correctionReceived.Set();
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnMessageCorrected += correctionHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat' id='c1'>" +
+					"<subject>New subject</subject>" +
+					"<body>New body</body>" +
+					"<replace xmlns='urn:xmpp:message-correct:0' id='orig1'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(correctionReceived.WaitOne(1000), "Correction event not received.");
+				Assert.AreEqual("orig1", replaceId, "Replace id mismatch.");
+				Assert.AreEqual("New body", newBody, "Body mismatch.");
+				Assert.AreEqual("New subject", newSubject, "Subject mismatch.");
+			}
+			finally
+			{
+				chatClient2.OnMessageCorrected -= correctionHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task MessageCorrection_Test_02_OutboundReplaceHasNewId()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			chatClient1.EnableMessageCorrection = true;
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Correction-Outbound-Sniffer");
+			this.client1.Add(sniffer);
+
+			try
+			{
+				await chatClient1.SendMessageCorrection(this.client2.BareJID, "orig42", "Corrected body", "Corrected subject", string.Empty, string.Empty);
+				await Task.Delay(250);
+
+				bool replaceFound = false;
+				bool messageIdFound = false;
+				bool hasOldMessageId = false;
+
+				foreach (SnifferEvent evt in sniffer.ToArray())
+				{
+					if (evt is not SnifferTxText tx)
+						continue;
+
+					if (!tx.Text.Contains("<message"))
+						continue;
+
+					try
+					{
+						XmlDocument doc = new XmlDocument();
+						doc.LoadXml(tx.Text);
+
+						if (doc.DocumentElement is null || doc.DocumentElement.LocalName != "message")
+							continue;
+
+						string stanzaId = doc.DocumentElement.GetAttribute("id");
+						if (!string.IsNullOrEmpty(stanzaId))
+						{
+							messageIdFound = true;
+							if (stanzaId == "orig42")
+								hasOldMessageId = true;
+						}
+
+						foreach (XmlNode node in doc.DocumentElement.ChildNodes)
+						{
+							if (node is XmlElement element &&
+								element.LocalName == "replace" &&
+								element.NamespaceURI == "urn:xmpp:message-correct:0" &&
+								element.GetAttribute("id") == "orig42")
+							{
+								replaceFound = true;
+								break;
+							}
+						}
+					}
+					catch (XmlException)
+					{
+						// Ignore non-stanza output
+					}
+				}
+
+				Assert.IsTrue(replaceFound, "Correction replace element not sent.");
+				Assert.IsTrue(messageIdFound, "Correction message should have a new stanza id.");
+				Assert.IsFalse(hasOldMessageId, "Correction message id should not match the replaced id.");
+			}
+			finally
+			{
+				this.client1.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient1.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task MessageCorrection_Test_03_NoSendForEmptyCorrection()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient1 = new ChatClient(this.client1);
+			chatClient1.EnableMessageCorrection = true;
+
+			InMemorySniffer sniffer = new InMemorySniffer(500, "Correction-Empty-Sniffer");
+			this.client1.Add(sniffer);
+
+			try
+			{
+				int baseline = sniffer.ToArray().Length;
+				await chatClient1.SendMessageCorrection(this.client2.BareJID, "orig-empty", string.Empty, string.Empty, string.Empty, string.Empty);
+				await Task.Delay(250);
+
+				SnifferEvent[] events = sniffer.ToArray();
+				bool replaceSent = false;
+
+				for (int i = baseline; i < events.Length; i++)
+				{
+					if (events[i] is SnifferTxText tx &&
+						tx.Text.Contains("<replace") &&
+						tx.Text.Contains("urn:xmpp:message-correct:0"))
+					{
+						replaceSent = true;
+						break;
+					}
+				}
+
+				Assert.IsFalse(replaceSent, "Empty correction should not send a replace stanza.");
+			}
+			finally
+			{
+				this.client1.Remove(sniffer);
+				sniffer.Dispose();
+				chatClient1.Dispose();
+				await this.DisposeClients();
+			}
+		}
+
+		[TestMethod]
+		public async Task MessageCorrection_Test_04_ReplaceOnlyDoesNotTriggerChatMessage()
+		{
+			await this.ConnectClients();
+
+			ChatClient chatClient2 = new ChatClient(this.client2);
+			chatClient2.EnableMessageCorrection = true;
+
+			using ManualResetEvent correctionReceived = new ManualResetEvent(false);
+			using ManualResetEvent chatMessageReceived = new ManualResetEvent(false);
+
+			EventHandlerAsync<MessageCorrectionEventArgs> correctionHandler = (sender, e) =>
+			{
+				if (e.ReplaceId == "orig55")
+					correctionReceived.Set();
+
+				return Task.CompletedTask;
+			};
+
+			EventHandlerAsync<MessageEventArgs> chatHandler = (sender, e) =>
+			{
+				chatMessageReceived.Set();
+				return Task.CompletedTask;
+			};
+
+			chatClient2.OnMessageCorrected += correctionHandler;
+			this.client2.OnChatMessage += chatHandler;
+
+			try
+			{
+				XmlDocument doc = new XmlDocument();
+				doc.LoadXml(
+					"<message from='" + this.client1.FullJID + "' to='" + this.client2.FullJID + "' type='chat' id='c2'>" +
+					"<replace xmlns='urn:xmpp:message-correct:0' id='orig55'/>" +
+					"</message>");
+
+				this.client2.ProcessMessage(new MessageEventArgs(this.client2, doc.DocumentElement));
+
+				Assert.IsTrue(correctionReceived.WaitOne(1000), "Correction event was not raised.");
+				Assert.IsFalse(chatMessageReceived.WaitOne(500), "Replace-only stanza should not trigger chat message handlers.");
+			}
+			finally
+			{
+				chatClient2.OnMessageCorrected -= correctionHandler;
+				this.client2.OnChatMessage -= chatHandler;
+				chatClient2.Dispose();
+				await this.DisposeClients();
+			}
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/ChatClient.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/ChatClient.cs
@@ -1,0 +1,1187 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml;
+using Waher.Content.Xml;
+using Waher.Events;
+using Waher.Networking.XMPP.Chat.ChatStates;
+using Waher.Networking.XMPP.Chat.Corrections;
+using Waher.Networking.XMPP.Chat.Markers;
+using Waher.Networking.XMPP.Chat.Receipts;
+using Waher.Networking.XMPP.Events;
+
+namespace Waher.Networking.XMPP.Chat
+{
+	/// <summary>
+	/// Chat-focused client that encapsulates user messaging behaviors,
+	/// delivery receipts (XEP-0184) https://xmpp.org/extensions/xep-0184.html
+	/// displayed markers (XEP-0333) https://xmpp.org/extensions/xep-0333.html,
+	/// message corrections (XEP-0308) https://xmpp.org/extensions/xep-0308.html
+	/// It registers message handlers on the underlying <see cref="XmppClient"/>, raises chat-specific events,
+	/// and forwards content messages to default message routing when appropriate.
+	/// </summary>
+	public class ChatClient : XmppExtension
+	{
+		/// <summary>
+		/// http://jabber.org/protocol/chatstates
+		/// </summary>
+		public const string NamespaceChatStates = "http://jabber.org/protocol/chatstates";
+		private const string NamespaceDelayedDelivery = "urn:xmpp:delay";
+		private const string NamespaceDelayedDeliveryLegacy = "jabber:x:delay";
+
+		private readonly Dictionary<string, ChatStateNegotiationState> chatStateNegotiation = new Dictionary<string, ChatStateNegotiationState>(StringComparer.OrdinalIgnoreCase);
+		private readonly Dictionary<string, ChatState> lastStandaloneState = new Dictionary<string, ChatState>(StringComparer.OrdinalIgnoreCase);
+		private readonly Dictionary<string, ChatState> lastStatePerContact = new Dictionary<string, ChatState>(StringComparer.OrdinalIgnoreCase);
+		private readonly Dictionary<string, string> currentThreadIdPerContact = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		private readonly HashSet<string> endedThreads = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		private readonly Dictionary<string, bool> chatStateCapabilitiesByNodeVersion = new Dictionary<string, bool>(StringComparer.Ordinal);
+		private readonly HashSet<string> pendingChatStateCapabilityRequests = new HashSet<string>(StringComparer.Ordinal);
+		private readonly object synchObject = new object();
+		private bool enableChatStateNotifications = false;
+		private bool enableDeliveryReceipts = false;
+		private bool enableChatMarkers = false;
+		private bool enableMessageCorrection = false;
+		private bool autoRespondToReceiptRequests = false;
+		private bool autoSendDisplayedMarkers = false;
+
+		/// <summary>
+		/// Chat-focused client that encapsulates user messaging behaviors,
+		/// delivery receipts (XEP-0184) https://xmpp.org/extensions/xep-0184.html
+		/// displayed markers (XEP-0333) https://xmpp.org/extensions/xep-0333.html,
+		/// message corrections (XEP-0308) https://xmpp.org/extensions/xep-0308.html
+		/// </summary>
+		/// <param name="Client">XMPP Client.</param>
+		public ChatClient(XmppClient Client)
+			: base(Client)
+		{
+			this.client.RegisterMessageHandler("active", NamespaceChatStates, this.ChatStateHandler, true);
+			this.client.RegisterMessageHandler("composing", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.RegisterMessageHandler("paused", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.RegisterMessageHandler("inactive", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.RegisterMessageHandler("gone", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.RegisterMessageHandler("request", DeliveryReceipts.NamespaceDeliveryReceipts, this.ReceiptRequestHandler, false);
+			this.client.RegisterMessageHandler("received", DeliveryReceipts.NamespaceDeliveryReceipts, this.ReceiptReceivedHandler, false);
+			this.client.RegisterMessageHandler("markable", ChatMarkers.NamespaceChatMarkers, this.ChatMarkerHandler, false);
+			this.client.RegisterMessageHandler("displayed", ChatMarkers.NamespaceChatMarkers, this.ChatMarkerHandler, false);
+			this.client.RegisterMessageHandler("replace", MessageCorrections.NamespaceMessageCorrection, this.MessageCorrectionHandler, false);
+
+			this.client.OnPresence += this.Client_OnPresence;
+			this.client.OnMessageReceived += this.Client_OnMessageReceived;
+			this.client.OnStateChanged += this.Client_OnStateChanged;
+		}
+
+		/// <inheritdoc/>
+		public override void Dispose()
+		{
+			this.client.UnregisterMessageHandler("active", NamespaceChatStates, this.ChatStateHandler, true);
+			this.client.UnregisterMessageHandler("composing", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.UnregisterMessageHandler("paused", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.UnregisterMessageHandler("inactive", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.UnregisterMessageHandler("gone", NamespaceChatStates, this.ChatStateHandler, false);
+			this.client.UnregisterMessageHandler("request", DeliveryReceipts.NamespaceDeliveryReceipts, this.ReceiptRequestHandler, false);
+			this.client.UnregisterMessageHandler("received", DeliveryReceipts.NamespaceDeliveryReceipts, this.ReceiptReceivedHandler, false);
+			this.client.UnregisterMessageHandler("markable", ChatMarkers.NamespaceChatMarkers, this.ChatMarkerHandler, false);
+			this.client.UnregisterMessageHandler("displayed", ChatMarkers.NamespaceChatMarkers, this.ChatMarkerHandler, false);
+			this.client.UnregisterMessageHandler("replace", MessageCorrections.NamespaceMessageCorrection, this.MessageCorrectionHandler, false);
+
+			this.client.OnPresence -= this.Client_OnPresence;
+			this.client.OnMessageReceived -= this.Client_OnMessageReceived;
+			this.client.OnStateChanged -= this.Client_OnStateChanged;
+
+			if (this.enableChatStateNotifications)
+				this.client.UnregisterFeature(NamespaceChatStates);
+			if (this.enableDeliveryReceipts)
+				this.client.UnregisterFeature(DeliveryReceipts.NamespaceDeliveryReceipts);
+			if (this.enableChatMarkers)
+				this.client.UnregisterFeature(ChatMarkers.NamespaceChatMarkers);
+			if (this.enableMessageCorrection)
+				this.client.UnregisterFeature(MessageCorrections.NamespaceMessageCorrection);
+
+			base.Dispose();
+		}
+
+		/// <summary>
+		/// Implemented extensions.
+		/// </summary>
+		public override string[] Extensions => new string[] { "XEP-0085", "XEP-0184", "XEP-0333", "XEP-0308" };
+
+		/// <summary>
+		/// If XEP-0085 chat state notifications are enabled for this client instance. Default is false.
+		/// </summary>
+		public bool EnableChatStateNotifications
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.enableChatStateNotifications;
+				}
+			}
+			set
+			{
+				bool Changed;
+
+				lock (this.synchObject)
+				{
+					Changed = this.enableChatStateNotifications != value;
+					this.enableChatStateNotifications = value;
+				}
+
+				if (!Changed)
+					return;
+
+				if (value)
+					this.client.RegisterFeature(NamespaceChatStates);
+				else
+					this.client.UnregisterFeature(NamespaceChatStates);
+			}
+		}
+
+		/// <summary>
+		/// If XEP-0184 message delivery receipts are enabled. Default is false.
+		/// </summary>
+		public bool EnableDeliveryReceipts
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.enableDeliveryReceipts;
+				}
+			}
+			set
+			{
+				bool Changed;
+
+				lock (this.synchObject)
+				{
+					Changed = this.enableDeliveryReceipts != value;
+					this.enableDeliveryReceipts = value;
+				}
+
+				if (!Changed)
+					return;
+
+				if (value)
+					this.client.RegisterFeature(DeliveryReceipts.NamespaceDeliveryReceipts);
+				else
+					this.client.UnregisterFeature(DeliveryReceipts.NamespaceDeliveryReceipts);
+			}
+		}
+
+		/// <summary>
+		/// If XEP-0333 displayed markers are enabled. Default is false.
+		/// </summary>
+		public bool EnableChatMarkers
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.enableChatMarkers;
+				}
+			}
+			set
+			{
+				bool Changed;
+
+				lock (this.synchObject)
+				{
+					Changed = this.enableChatMarkers != value;
+					this.enableChatMarkers = value;
+				}
+
+				if (!Changed)
+					return;
+
+				if (value)
+					this.client.RegisterFeature(ChatMarkers.NamespaceChatMarkers);
+				else
+					this.client.UnregisterFeature(ChatMarkers.NamespaceChatMarkers);
+			}
+		}
+
+		/// <summary>
+		/// If XEP-0308 message correction is enabled. Default is false.
+		/// </summary>
+		public bool EnableMessageCorrection
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.enableMessageCorrection;
+				}
+			}
+			set
+			{
+				bool Changed;
+
+				lock (this.synchObject)
+				{
+					Changed = this.enableMessageCorrection != value;
+					this.enableMessageCorrection = value;
+				}
+
+				if (!Changed)
+					return;
+
+				if (value)
+					this.client.RegisterFeature(MessageCorrections.NamespaceMessageCorrection);
+				else
+					this.client.UnregisterFeature(MessageCorrections.NamespaceMessageCorrection);
+			}
+		}
+
+		/// <summary>
+		/// If receipt requests should be auto-acknowledged. Default is false.
+		/// </summary>
+		public bool AutoRespondToReceiptRequests
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.autoRespondToReceiptRequests;
+				}
+			}
+			set
+			{
+				lock (this.synchObject)
+				{
+					this.autoRespondToReceiptRequests = value;
+				}
+			}
+		}
+
+		/// <summary>
+		/// If displayed markers should be sent automatically. Default is false.
+		/// </summary>
+		public bool AutoSendDisplayedMarkers
+		{
+			get
+			{
+				lock (this.synchObject)
+				{
+					return this.autoSendDisplayedMarkers;
+				}
+			}
+			set
+			{
+				lock (this.synchObject)
+				{
+					this.autoSendDisplayedMarkers = value;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Raised when chat state support has been determined for a contact.
+		/// </summary>
+		public event ChatStateSupportDeterminedEventHandler OnChatStateSupportDetermined = null;
+
+		/// <summary>
+		/// Unified chat state changed event.
+		/// </summary>
+		public event EventHandlerAsync<ChatStateEventArgs> OnChatStateChanged = null;
+
+		/// <summary>
+		/// Raised when composing chat state received.
+		/// </summary>
+		public event EventHandlerAsync<MessageEventArgs> OnChatComposing = null;
+
+		/// <summary>
+		/// Raised when active chat state received.
+		/// </summary>
+		public event EventHandlerAsync<MessageEventArgs> OnChatActive = null;
+
+		/// <summary>
+		/// Raised when paused chat state received.
+		/// </summary>
+		public event EventHandlerAsync<MessageEventArgs> OnChatPaused = null;
+
+		/// <summary>
+		/// Raised when inactive chat state received.
+		/// </summary>
+		public event EventHandlerAsync<MessageEventArgs> OnChatInactive = null;
+
+		/// <summary>
+		/// Raised when gone chat state received.
+		/// </summary>
+		public event EventHandlerAsync<MessageEventArgs> OnChatGone = null;
+
+		/// <summary>
+		/// Raised when a delivery receipt request is received.
+		/// </summary>
+		public event EventHandlerAsync<DeliveryReceiptEventArgs> OnReceiptRequest = null;
+
+		/// <summary>
+		/// Raised when a delivery receipt is received.
+		/// </summary>
+		public event EventHandlerAsync<DeliveryReceiptEventArgs> OnReceiptReceived = null;
+
+		/// <summary>
+		/// Raised when a chat marker is received.
+		/// </summary>
+		public event EventHandlerAsync<ChatMarkerEventArgs> OnChatMarker = null;
+
+		/// <summary>
+		/// Raised when a message correction is received.
+		/// </summary>
+		public event EventHandlerAsync<MessageCorrectionEventArgs> OnMessageCorrected = null;
+
+		/// <summary>
+		/// Returns if chat state notifications are known to be supported for the bare JID.
+		/// </summary>
+		/// <param name="BareJid">Bare JID.</param>
+		/// <returns>If chat states are supported.</returns>
+		public bool IsChatStateSupported(string BareJid)
+		{
+			if (string.IsNullOrEmpty(BareJid))
+				return false;
+
+			lock (this.synchObject)
+			{
+				return this.chatStateNegotiation.TryGetValue(BareJid, out ChatStateNegotiationState state) && state == ChatStateNegotiationState.Supported;
+			}
+		}
+
+		/// <summary>
+		/// Sends a chat-state notification stanza. Obeys <see cref="EnableChatStateNotifications"/> and negotiation state.
+		/// </summary>
+		/// <param name="To">Destination bare or full JID.</param>
+		/// <param name="State">Chat state to send.</param>
+		/// <param name="ThreadId">Thread identifier.</param>
+		/// <param name="ParentThreadId">Optional parent thread identifier.</param>
+		public Task SendChatState(string To, ChatState State, string ThreadId = "", string ParentThreadId = "")
+		{
+			return this.SendStandaloneChatState(To, State, MessageType.Chat, ThreadId, ParentThreadId);
+		}
+
+		/// <summary>
+		/// Sends a standalone chat-state notification, enforcing negotiation, duplicate suppression, and thread rules.
+		/// Standalone <active/> notifications are suppressed per XEP-0085 guidance.
+		/// </summary>
+		/// <param name="To">Destination bare or full JID.</param>
+		/// <param name="State">Chat state to send.</param>
+		/// <param name="Type">Message type (chat or groupchat).</param>
+		/// <param name="ThreadId">Thread identifier.</param>
+		/// <param name="ParentThreadId">Optional parent thread identifier.</param>
+		public Task SendStandaloneChatState(string To, ChatState State, MessageType Type = MessageType.Chat, string ThreadId = "", string ParentThreadId = "")
+		{
+			if (string.IsNullOrEmpty(To))
+				return Task.CompletedTask;
+
+			if (Type != MessageType.Chat && Type != MessageType.GroupChat)
+				throw new ArgumentOutOfRangeException(nameof(Type), "Chat state notifications are only valid for chat or groupchat messages.");
+
+			if (!this.EnableChatStateNotifications)
+				return Task.CompletedTask;
+
+			if (State == ChatState.Active)
+				return Task.CompletedTask;
+
+			if (Type == MessageType.GroupChat && State == ChatState.Gone)
+				return Task.CompletedTask;
+
+			string BareJid = XmppClient.GetBareJID(To);
+			if (string.IsNullOrEmpty(BareJid))
+				BareJid = To;
+
+			string ResolvedThreadId = ThreadId;
+			bool WillSend;
+
+			lock (this.synchObject)
+			{
+				ChatStateNegotiationState NegotiationState = this.chatStateNegotiation.TryGetValue(BareJid, out ChatStateNegotiationState Tmp) ? Tmp : ChatStateNegotiationState.Unknown;
+				WillSend = NegotiationState != ChatStateNegotiationState.NotSupported;
+
+				if (WillSend && string.IsNullOrEmpty(ResolvedThreadId) && this.currentThreadIdPerContact.TryGetValue(BareJid, out string CurrentThread))
+					ResolvedThreadId = CurrentThread;
+
+				string StandaloneKey = ComposeStandaloneStateKey(BareJid, ResolvedThreadId);
+				if (WillSend && this.lastStandaloneState.TryGetValue(StandaloneKey, out ChatState LastState) && LastState == State)
+					WillSend = false;
+
+				if (WillSend && State == ChatState.Gone && Type != MessageType.GroupChat && !string.IsNullOrEmpty(ResolvedThreadId))
+				{
+					string Key = ComposeThreadKey(BareJid, ResolvedThreadId);
+					if (this.endedThreads.Contains(Key))
+						WillSend = false;
+					else
+					{
+						this.endedThreads.Add(Key);
+						this.currentThreadIdPerContact.Remove(BareJid);
+					}
+				}
+
+				if (WillSend)
+					this.lastStandaloneState[StandaloneKey] = State;
+			}
+
+			if (!WillSend)
+				return Task.CompletedTask;
+
+			string LocalName = GetLocalName(State);
+			string Xml = "<" + LocalName + " xmlns='" + NamespaceChatStates + "'/>";
+
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, string.Empty, To, Xml, string.Empty, string.Empty, string.Empty,
+				ResolvedThreadId, ParentThreadId, null, null);
+		}
+
+		/// <summary>
+		/// Sends a chat content message ensuring chat-state negotiation rules are applied.
+		/// </summary>
+		/// <param name="To">Destination address.</param>
+		/// <param name="Body">Body text.</param>
+		/// <param name="Subject">Optional subject.</param>
+		/// <param name="Language">Language code.</param>
+		/// <param name="ThreadId">Thread identifier.</param>
+		/// <param name="ParentThreadId">Optional parent thread identifier.</param>
+		public Task SendChatContentMessage(string To, string Body, string Subject, string Language, string ThreadId, string ParentThreadId)
+		{
+			return this.SendChatContentMessageInternal(MessageType.Chat, To, Body, Subject, Language, ThreadId, ParentThreadId, string.Empty, string.Empty);
+		}
+
+		/// <summary>
+		/// Sends a chat content message with extra payload XML.
+		/// </summary>
+		/// <param name="To">Destination address.</param>
+		/// <param name="Body">Body text.</param>
+		/// <param name="Subject">Optional subject.</param>
+		/// <param name="Language">Language code.</param>
+		/// <param name="ThreadId">Thread identifier.</param>
+		/// <param name="ParentThreadId">Optional parent thread identifier.</param>
+		/// <param name="CustomXml">Custom XML payload.</param>
+		/// <param name="MessageId">Message stanza id.</param>
+		public Task SendChatContentMessage(string To, string Body, string Subject, string Language, string ThreadId, string ParentThreadId, string CustomXml, string MessageId)
+		{
+			return this.SendChatContentMessageInternal(MessageType.Chat, To, Body, Subject, Language, ThreadId, ParentThreadId, CustomXml, MessageId);
+		}
+
+		private Task SendChatContentMessageInternal(MessageType Type, string To, string Body, string Subject, string Language, string ThreadId,
+			string ParentThreadId, string CustomXml, string MessageId)
+		{
+			bool HasSubject = !string.IsNullOrEmpty(Subject);
+			bool HasBody = !string.IsNullOrEmpty(Body);
+			bool IsContentMessage = HasBody || HasSubject;
+			string BareJid = string.Empty;
+
+			if (!string.IsNullOrEmpty(To))
+			{
+				BareJid = XmppClient.GetBareJID(To);
+				if (string.IsNullOrEmpty(BareJid))
+					BareJid = To;
+			}
+
+			if (Type == MessageType.Chat && !string.IsNullOrEmpty(BareJid))
+				ThreadId = this.EnsureOutgoingThreadId(BareJid, ThreadId, IsContentMessage);
+
+			string ResolvedCustomXml = CustomXml ?? string.Empty;
+			bool ShouldEmbedActive = false;
+
+			if (Type == MessageType.Chat && this.EnableChatStateNotifications && !string.IsNullOrEmpty(BareJid) && IsContentMessage)
+			{
+				ChatStateNegotiationState NegotiationState;
+				lock (this.synchObject)
+				{
+					NegotiationState = this.chatStateNegotiation.TryGetValue(BareJid, out ChatStateNegotiationState tmp) ? tmp : ChatStateNegotiationState.Unknown;
+				}
+
+				if (NegotiationState != ChatStateNegotiationState.NotSupported)
+				{
+					ShouldEmbedActive = true;
+
+					if (NegotiationState == ChatStateNegotiationState.Unknown)
+						this.TryUpdateNegotiationState(BareJid, ChatStateNegotiationState.Requested, out _);
+				}
+			}
+
+			if (ShouldEmbedActive)
+				ResolvedCustomXml += "<" + GetLocalName(ChatState.Active) + " xmlns='" + NamespaceChatStates + "'/>";
+
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, MessageId ?? string.Empty, To, ResolvedCustomXml, Body, Subject, Language,
+				ThreadId, ParentThreadId, null, null);
+		}
+
+		/// <summary>
+		/// Sends a composing chat-state notification.
+		/// </summary>
+		public Task SendComposing(string To, string ThreadId = "", string ParentThreadId = "") => this.SendStandaloneChatState(To, ChatState.Composing, MessageType.Chat, ThreadId, ParentThreadId);
+		/// <summary>
+		/// Sends an active chat-state notification. Standalone <active/> is suppressed; use content messages to include it.
+		/// </summary>
+		public Task SendActive(string To, string ThreadId = "", string ParentThreadId = "") => this.SendStandaloneChatState(To, ChatState.Active, MessageType.Chat, ThreadId, ParentThreadId);
+		/// <summary>
+		/// Sends a paused chat-state notification.
+		/// </summary>
+		public Task SendPaused(string To, string ThreadId = "", string ParentThreadId = "") => this.SendStandaloneChatState(To, ChatState.Paused, MessageType.Chat, ThreadId, ParentThreadId);
+
+		/// <summary>
+		/// Sends an inactive chat-state notification.
+		/// </summary>
+		public Task SendInactive(string To, string ThreadId = "", string ParentThreadId = "") => this.SendStandaloneChatState(To, ChatState.Inactive, MessageType.Chat, ThreadId, ParentThreadId);
+
+		/// <summary>
+		/// Sends a gone chat-state notification.
+		/// </summary>
+		public Task SendGone(string To, string ThreadId = "", string ParentThreadId = "") => this.SendStandaloneChatState(To, ChatState.Gone, MessageType.Chat, ThreadId, ParentThreadId);
+
+		/// <summary>
+		/// Sends a simple chat message.
+		/// </summary>
+		public Task SendChatMessage(string To, string Body) =>
+			this.SendChatContentMessage(To, Body, string.Empty, string.Empty, string.Empty, string.Empty);
+
+		/// <summary>
+		/// Sends a simple chat message.
+		/// </summary>
+		public Task SendChatMessage(string To, string Body, string Subject) =>
+			this.SendChatContentMessage(To, Body, Subject, string.Empty, string.Empty, string.Empty);
+
+		/// <summary>
+		/// Sends a simple chat message.
+		/// </summary>
+		public Task SendChatMessage(string To, string Body, string Subject, string Language) =>
+			this.SendChatContentMessage(To, Body, Subject, Language, string.Empty, string.Empty);
+
+		/// <summary>
+		/// Sends a simple chat message.
+		/// </summary>
+		public Task SendChatMessage(string To, string Body, string Subject, string Language, string ThreadId) =>
+			this.SendChatContentMessage(To, Body, Subject, Language, ThreadId, string.Empty);
+
+		/// <summary>
+		/// Sends a simple chat message.
+		/// </summary>
+		public Task SendChatMessage(string To, string Body, string Subject, string Language, string ThreadId, string ParentThreadId) =>
+			this.SendChatContentMessage(To, Body, Subject, Language, ThreadId, ParentThreadId);
+
+		/// <summary>
+		/// Sends a chat message requesting a delivery receipt (XEP-0184).
+		/// </summary>
+		public Task SendChatMessageWithReceiptRequest(string To, string Body, string MessageId) =>
+			this.SendChatMessageWithReceiptRequest(To, Body, string.Empty, string.Empty, string.Empty, string.Empty, MessageId);
+
+		/// <summary>
+		/// Sends a chat message requesting a delivery receipt (XEP-0184).
+		/// </summary>
+		public Task SendChatMessageWithReceiptRequest(string To, string Body, string Subject, string Language, string ThreadId, string ParentThreadId, string MessageId)
+		{
+			if (!this.EnableDeliveryReceipts || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			string Xml = "<request xmlns='" + DeliveryReceipts.NamespaceDeliveryReceipts + "'/>";
+			return this.SendChatContentMessageInternal(MessageType.Chat, To, Body, Subject, Language, ThreadId, ParentThreadId, Xml, MessageId);
+		}
+
+		/// <summary>
+		/// Sends a standalone receipt request (XEP-0184).
+		/// </summary>
+		public Task SendReceiptRequest(string To, string MessageId, MessageType Type = MessageType.Chat, string ThreadId = "", string ParentThreadId = "")
+		{
+			if (!this.EnableDeliveryReceipts || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			if (Type != MessageType.Chat)
+				return Task.CompletedTask;
+
+			string Xml = "<request xmlns='" + DeliveryReceipts.NamespaceDeliveryReceipts + "'/>";
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, MessageId, To, Xml, string.Empty, string.Empty, string.Empty,
+				ThreadId, ParentThreadId, null, null);
+		}
+
+		/// <summary>
+		/// Sends a delivery receipt (XEP-0184).
+		/// </summary>
+		public Task SendReceiptReceived(string To, string MessageId, MessageType Type = MessageType.Chat)
+		{
+			if (!this.EnableDeliveryReceipts || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			if (Type != MessageType.Chat)
+				return Task.CompletedTask;
+
+			string Xml = "<received xmlns='" + DeliveryReceipts.NamespaceDeliveryReceipts + "' id='" + XML.Encode(MessageId) + "'/>";
+			string AckId = this.client.NextId();
+
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, AckId, To, Xml, string.Empty, string.Empty, string.Empty,
+				string.Empty, string.Empty, null, null);
+		}
+
+		/// <summary>
+		/// Sends a chat message marking it as markable (XEP-0333).
+		/// </summary>
+		public Task SendChatMessageMarkable(string To, string Body, string MessageId) =>
+			this.SendChatMessageMarkable(To, Body, string.Empty, string.Empty, string.Empty, string.Empty, MessageId);
+
+		/// <summary>
+		/// Sends a chat message marking it as markable (XEP-0333).
+		/// </summary>
+		public Task SendChatMessageMarkable(string To, string Body, string Subject, string Language, string ThreadId, string ParentThreadId, string MessageId)
+		{
+			if (!this.EnableChatMarkers || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			string Xml = "<markable xmlns='" + ChatMarkers.NamespaceChatMarkers + "'/>";
+			return this.SendChatContentMessageInternal(MessageType.Chat, To, Body, Subject, Language, ThreadId, ParentThreadId, Xml, MessageId);
+		}
+
+		/// <summary>
+		/// Sends a standalone markable marker (XEP-0333).
+		/// </summary>
+		public Task SendMarkable(string To, string MessageId, MessageType Type = MessageType.Chat)
+		{
+			if (!this.EnableChatMarkers || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			if (Type != MessageType.Chat)
+				return Task.CompletedTask;
+
+			string Xml = "<markable xmlns='" + ChatMarkers.NamespaceChatMarkers + "'/>";
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, MessageId, To, Xml, string.Empty, string.Empty, string.Empty,
+				string.Empty, string.Empty, null, null);
+		}
+
+		/// <summary>
+		/// Sends a displayed marker (XEP-0333).
+		/// </summary>
+		public Task SendDisplayedMarker(string To, string MessageId, MessageType Type = MessageType.Chat)
+		{
+			if (!this.EnableChatMarkers || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(MessageId))
+				return Task.CompletedTask;
+
+			if (Type != MessageType.Chat)
+				return Task.CompletedTask;
+
+			string Xml = "<displayed xmlns='" + ChatMarkers.NamespaceChatMarkers + "' id='" + XML.Encode(MessageId) + "'/>";
+			string MarkerId = this.client.NextId();
+
+			return this.client.SendMessage(QoSLevel.Unacknowledged, Type, MarkerId, To, Xml, string.Empty, string.Empty, string.Empty,
+				string.Empty, string.Empty, null, null);
+		}
+
+		/// <summary>
+		/// Sends a message correction (XEP-0308).
+		/// </summary>
+		public Task SendMessageCorrection(string To, string ReplaceId, string NewBody, string NewSubject, string Language, string ThreadId, string ParentThreadId = "")
+		{
+			if (!this.EnableMessageCorrection || string.IsNullOrEmpty(To) || string.IsNullOrEmpty(ReplaceId))
+				return Task.CompletedTask;
+
+			if (string.IsNullOrEmpty(NewBody) && string.IsNullOrEmpty(NewSubject))
+				return Task.CompletedTask;
+
+			string NewId = this.client.NextId();
+			string Xml = "<replace xmlns='" + MessageCorrections.NamespaceMessageCorrection + "' id='" + XML.Encode(ReplaceId) + "'/>";
+
+			return this.SendChatContentMessageInternal(MessageType.Chat, To, NewBody, NewSubject, Language, ThreadId, ParentThreadId, Xml, NewId);
+		}
+
+		private Task Client_OnPresence(object Sender, PresenceEventArgs e)
+		{
+			this.EvaluateChatStateCapabilities(e);
+			return Task.CompletedTask;
+		}
+
+		private Task Client_OnMessageReceived(object Sender, MessageEventArgs e)
+		{
+			return this.EvaluateIncomingChatStateSupport(e);
+		}
+
+		private Task Client_OnStateChanged(object Sender, XmppState NewState)
+		{
+			switch (NewState)
+			{
+				case XmppState.Offline:
+				case XmppState.Error:
+					this.ResetState();
+					break;
+			}
+
+			return Task.CompletedTask;
+		}
+
+		private void ResetState()
+		{
+			lock (this.synchObject)
+			{
+				this.chatStateNegotiation.Clear();
+				this.lastStandaloneState.Clear();
+				this.lastStatePerContact.Clear();
+				this.currentThreadIdPerContact.Clear();
+				this.endedThreads.Clear();
+				this.pendingChatStateCapabilityRequests.Clear();
+			}
+		}
+
+		private async Task ChatStateHandler(object Sender, MessageEventArgs e)
+		{
+			if (!(e.Content is XmlElement Element) || Element.NamespaceURI != NamespaceChatStates)
+				return;
+
+			ChatState State = GetChatStateFromLocalName(Element.LocalName);
+			if (e.Type == MessageType.GroupChat && State == ChatState.Gone)
+			{
+				if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+					await this.client.RaiseMessageEventAsync(e);
+				return;
+			}
+
+			string BareJid = XmppClient.GetBareJID(e.From);
+			ChatState PreviousState = ChatState.Active;
+
+			if (!string.IsNullOrEmpty(BareJid))
+			{
+				if (this.TryUpdateNegotiationState(BareJid, ChatStateNegotiationState.Supported, out ChatStateNegotiationState PreviousNegotiation) &&
+					PreviousNegotiation != ChatStateNegotiationState.Supported)
+				{
+					await this.RaiseChatStateSupportDeterminedAsync(BareJid, true);
+				}
+
+				PreviousState = this.UpdateLastStateForContact(BareJid, State);
+				this.HandleThreadTrackingForIncomingState(BareJid, State, e);
+			}
+
+			await this.RaiseChatStateEvents(State, PreviousState, e);
+
+			if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+				await this.client.RaiseMessageEventAsync(e);
+		}
+
+		private async Task ReceiptRequestHandler(object Sender, MessageEventArgs e)
+		{
+			if (!(e.Content is XmlElement Element) || Element.NamespaceURI != DeliveryReceipts.NamespaceDeliveryReceipts || Element.LocalName != "request")
+				return;
+
+			string Id = e.Id ?? string.Empty;
+			EventHandlerAsync<DeliveryReceiptEventArgs> Handler = this.OnReceiptRequest;
+			if (!(Handler is null))
+				await Handler.Raise(this, new DeliveryReceiptEventArgs(e, Id, true));
+
+			bool AutoRespond;
+			lock (this.synchObject)
+			{
+				AutoRespond = this.enableDeliveryReceipts && this.autoRespondToReceiptRequests;
+			}
+
+			if (AutoRespond && e.Type == MessageType.Chat && !string.IsNullOrEmpty(Id) && !HasDelayedDelivery(e))
+				await this.SendReceiptReceived(e.From, Id, MessageType.Chat);
+
+			if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+				await this.client.RaiseMessageEventAsync(e);
+		}
+
+		private async Task ReceiptReceivedHandler(object Sender, MessageEventArgs e)
+		{
+			if (!(e.Content is XmlElement Element) || Element.NamespaceURI != DeliveryReceipts.NamespaceDeliveryReceipts || Element.LocalName != "received")
+				return;
+
+			string Id = Element.GetAttribute("id");
+			if (string.IsNullOrEmpty(Id))
+				return;
+
+			EventHandlerAsync<DeliveryReceiptEventArgs> Handler = this.OnReceiptReceived;
+			if (!(Handler is null))
+				await Handler.Raise(this, new DeliveryReceiptEventArgs(e, Id, false));
+
+			if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+				await this.client.RaiseMessageEventAsync(e);
+		}
+
+		private async Task ChatMarkerHandler(object Sender, MessageEventArgs e)
+		{
+			if (!(e.Content is XmlElement Element) || Element.NamespaceURI != ChatMarkers.NamespaceChatMarkers)
+				return;
+
+			ChatMarkerType MarkerType;
+			string Id = string.Empty;
+
+			switch (Element.LocalName)
+			{
+				case "markable":
+					MarkerType = ChatMarkerType.Markable;
+					Id = e.Id ?? string.Empty;
+					break;
+
+				case "displayed":
+					MarkerType = ChatMarkerType.Displayed;
+					Id = Element.GetAttribute("id");
+					if (string.IsNullOrEmpty(Id))
+						return;
+					break;
+
+				default:
+					return;
+			}
+
+			EventHandlerAsync<ChatMarkerEventArgs> Handler = this.OnChatMarker;
+			if (!(Handler is null))
+				await Handler.Raise(this, new ChatMarkerEventArgs(e, MarkerType, Id));
+
+			bool AutoSend;
+			lock (this.synchObject)
+			{
+				AutoSend = this.enableChatMarkers && this.autoSendDisplayedMarkers;
+			}
+
+			if (MarkerType == ChatMarkerType.Markable && AutoSend && e.Type == MessageType.Chat && !string.IsNullOrEmpty(e.Id) && !HasDelayedDelivery(e))
+				await this.SendDisplayedMarker(e.From, e.Id, MessageType.Chat);
+
+			if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+				await this.client.RaiseMessageEventAsync(e);
+		}
+
+		private async Task MessageCorrectionHandler(object Sender, MessageEventArgs e)
+		{
+			if (!(e.Content is XmlElement Element) || Element.NamespaceURI != MessageCorrections.NamespaceMessageCorrection || Element.LocalName != "replace")
+				return;
+
+			string ReplaceId = Element.GetAttribute("id");
+			if (string.IsNullOrEmpty(ReplaceId))
+				return;
+
+			EventHandlerAsync<MessageCorrectionEventArgs> Handler = this.OnMessageCorrected;
+			if (!(Handler is null))
+				await Handler.Raise(this, new MessageCorrectionEventArgs(e, ReplaceId, e.Body, e.Subject));
+
+			if (!string.IsNullOrEmpty(e.Body) || !string.IsNullOrEmpty(e.Subject))
+				await this.client.RaiseMessageEventAsync(e);
+		}
+
+		private bool TryUpdateNegotiationState(string BareJid, ChatStateNegotiationState NewState, out ChatStateNegotiationState PreviousState)
+		{
+			if (string.IsNullOrEmpty(BareJid))
+			{
+				PreviousState = ChatStateNegotiationState.Unknown;
+				return false;
+			}
+
+			lock (this.synchObject)
+			{
+				if (!this.chatStateNegotiation.TryGetValue(BareJid, out PreviousState))
+					PreviousState = ChatStateNegotiationState.Unknown;
+
+				if (PreviousState == NewState)
+					return false;
+
+				if (PreviousState == ChatStateNegotiationState.NotSupported && NewState == ChatStateNegotiationState.Requested)
+					return false;
+
+				this.chatStateNegotiation[BareJid] = NewState;
+				return true;
+			}
+		}
+
+		private ChatState UpdateLastStateForContact(string BareJid, ChatState NewState)
+		{
+			lock (this.synchObject)
+			{
+				if (!this.lastStatePerContact.TryGetValue(BareJid, out ChatState Previous))
+					Previous = ChatState.Active;
+
+				this.lastStatePerContact[BareJid] = NewState;
+				return Previous;
+			}
+		}
+
+		private void HandleThreadTrackingForIncomingState(string BareJid, ChatState State, MessageEventArgs e)
+		{
+			lock (this.synchObject)
+			{
+				if (!string.IsNullOrEmpty(e.ThreadID))
+					this.currentThreadIdPerContact[BareJid] = e.ThreadID;
+
+				if (State == ChatState.Gone && e.Type != MessageType.GroupChat && !string.IsNullOrEmpty(e.ThreadID))
+				{
+					string Key = ComposeThreadKey(BareJid, e.ThreadID);
+					this.endedThreads.Add(Key);
+
+					if (this.currentThreadIdPerContact.TryGetValue(BareJid, out string current) && current == e.ThreadID)
+						this.currentThreadIdPerContact.Remove(BareJid);
+				}
+			}
+		}
+
+		private async Task RaiseChatStateEvents(ChatState State, ChatState PreviousState, MessageEventArgs e)
+		{
+			this.Information("OnChatStateChanged()");
+			EventHandlerAsync<ChatStateEventArgs> Changed = this.OnChatStateChanged;
+			if (!(Changed is null))
+				await Changed.Raise(this, new ChatStateEventArgs(e, State, PreviousState));
+
+			EventHandlerAsync<MessageEventArgs> Specific = State switch
+			{
+				ChatState.Composing => this.OnChatComposing,
+				ChatState.Active => this.OnChatActive,
+				ChatState.Paused => this.OnChatPaused,
+				ChatState.Inactive => this.OnChatInactive,
+				ChatState.Gone => this.OnChatGone,
+				_ => null
+			};
+
+			if (!(Specific is null))
+				await Specific.Raise(this, e);
+		}
+
+		private async Task RaiseChatStateSupportDeterminedAsync(string BareJid, bool Supported)
+		{
+			ChatStateSupportDeterminedEventHandler Callback = this.OnChatStateSupportDetermined;
+			if (!(Callback is null))
+			{
+				try
+				{
+					Task Task = Callback(BareJid, Supported);
+					if (!(Task is null))
+						await Task.ConfigureAwait(false);
+				}
+				catch (Exception Ex)
+				{
+					this.Exception(Ex);
+				}
+			}
+		}
+
+		private static string ComposeThreadKey(string BareJid, string ThreadId)
+		{
+			return BareJid + "|" + ThreadId;
+		}
+
+		private static string ComposeStandaloneStateKey(string BareJid, string ThreadId)
+		{
+			if (string.IsNullOrEmpty(ThreadId))
+				return BareJid;
+
+			return ComposeThreadKey(BareJid, ThreadId);
+		}
+
+		private static ChatState GetChatStateFromLocalName(string LocalName)
+		{
+			return LocalName switch
+			{
+				"composing" => ChatState.Composing,
+				"paused" => ChatState.Paused,
+				"inactive" => ChatState.Inactive,
+				"gone" => ChatState.Gone,
+				_ => ChatState.Active
+			};
+		}
+
+		private static string GetLocalName(ChatState State)
+		{
+			return State switch
+			{
+				ChatState.Composing => "composing",
+				ChatState.Paused => "paused",
+				ChatState.Inactive => "inactive",
+				ChatState.Gone => "gone",
+				_ => "active"
+			};
+		}
+
+		private void EvaluateChatStateCapabilities(PresenceEventArgs e)
+		{
+			if (!this.EnableChatStateNotifications || e.Type != PresenceType.Available)
+				return;
+
+			string BareJid = e.FromBareJID;
+			if (string.IsNullOrEmpty(BareJid))
+				return;
+
+			string Node = e.EntityCapabilityNode;
+			string Version = e.EntityCapabilityVersion;
+			if (string.IsNullOrEmpty(Node) || string.IsNullOrEmpty(Version))
+				return;
+
+			string Key = Node + "#" + Version;
+			bool Supported;
+
+			lock (this.synchObject)
+			{
+				if (this.chatStateCapabilitiesByNodeVersion.TryGetValue(Key, out Supported))
+				{
+					_ = this.ApplyCapabilityNegotiationAsync(BareJid, Supported);
+					return;
+				}
+
+				if (!this.pendingChatStateCapabilityRequests.Add(Key))
+					return;
+			}
+
+			string DiscoNode = Node + "#" + Version;
+
+			try
+			{
+				_ = this.client.SendServiceDiscoveryRequest(e.From, DiscoNode, async (sender, args) =>
+				{
+					bool Supports = false;
+
+					if (args.Ok)
+						Supports = args.HasFeature(NamespaceChatStates);
+
+					lock (this.synchObject)
+					{
+						this.chatStateCapabilitiesByNodeVersion[Key] = Supports;
+						this.pendingChatStateCapabilityRequests.Remove(Key);
+					}
+
+					await this.ApplyCapabilityNegotiationAsync(BareJid, Supports);
+				}, null);
+			}
+			catch (Exception Ex)
+			{
+				lock (this.synchObject)
+				{
+					this.pendingChatStateCapabilityRequests.Remove(Key);
+				}
+
+				this.Exception(Ex);
+			}
+		}
+
+		private async Task ApplyCapabilityNegotiationAsync(string BareJid, bool Supported)
+		{
+			if (string.IsNullOrEmpty(BareJid))
+				return;
+
+			if (Supported)
+			{
+				if (this.TryUpdateNegotiationState(BareJid, ChatStateNegotiationState.Supported, out ChatStateNegotiationState Previous) &&
+					Previous != ChatStateNegotiationState.Supported)
+				{
+					await this.RaiseChatStateSupportDeterminedAsync(BareJid, true);
+				}
+			}
+			else
+			{
+				bool Changed = false;
+
+				lock (this.synchObject)
+				{
+					if (!this.chatStateNegotiation.TryGetValue(BareJid, out ChatStateNegotiationState Previous) || Previous != ChatStateNegotiationState.NotSupported)
+					{
+						this.chatStateNegotiation[BareJid] = ChatStateNegotiationState.NotSupported;
+						Changed = true;
+					}
+				}
+
+				if (Changed)
+					await this.RaiseChatStateSupportDeterminedAsync(BareJid, false);
+			}
+		}
+
+		private async Task EvaluateIncomingChatStateSupport(MessageEventArgs e)
+		{
+			if (e is null)
+				return;
+
+			string BareJid = XmppClient.GetBareJID(e.From);
+			if (string.IsNullOrEmpty(BareJid))
+				BareJid = e.From;
+			if (string.IsNullOrEmpty(BareJid))
+				return;
+
+			if (!string.IsNullOrEmpty(e.ThreadID) && (e.Type == MessageType.Chat || e.Type == MessageType.GroupChat))
+			{
+				lock (this.synchObject)
+				{
+					this.currentThreadIdPerContact[BareJid] = e.ThreadID;
+				}
+			}
+
+			if (!this.EnableChatStateNotifications || e.Type != MessageType.Chat)
+				return;
+
+			bool HasChatState = false;
+			foreach (XmlNode Node in e.Message.ChildNodes)
+			{
+				if (Node is XmlElement Element && Element.NamespaceURI == NamespaceChatStates)
+				{
+					HasChatState = true;
+					break;
+				}
+			}
+
+			if (HasChatState)
+			{
+				if (this.TryUpdateNegotiationState(BareJid, ChatStateNegotiationState.Supported, out ChatStateNegotiationState Previous) &&
+					Previous != ChatStateNegotiationState.Supported)
+				{
+					await this.RaiseChatStateSupportDeterminedAsync(BareJid, true);
+				}
+			}
+			else
+			{
+				bool Changed = false;
+				lock (this.synchObject)
+				{
+					if (this.chatStateNegotiation.TryGetValue(BareJid, out ChatStateNegotiationState Previous) &&
+						Previous == ChatStateNegotiationState.Requested)
+					{
+						this.chatStateNegotiation[BareJid] = ChatStateNegotiationState.NotSupported;
+						Changed = true;
+					}
+				}
+
+				if (Changed)
+					await this.RaiseChatStateSupportDeterminedAsync(BareJid, false);
+			}
+		}
+
+		private static bool HasDelayedDelivery(MessageEventArgs e)
+		{
+			if (e?.Message is null)
+				return false;
+
+			foreach (XmlNode Node in e.Message.ChildNodes)
+			{
+				if (Node is XmlElement Element)
+				{
+					if (Element.LocalName == "delay" && Element.NamespaceURI == NamespaceDelayedDelivery)
+						return true;
+
+					if (Element.LocalName == "x" && Element.NamespaceURI == NamespaceDelayedDeliveryLegacy)
+						return true;
+				}
+			}
+
+			return false;
+		}
+
+		private string EnsureOutgoingThreadId(string BareJid, string RequestedThreadId, bool IsContentMessage)
+		{
+			if (string.IsNullOrEmpty(BareJid))
+				return RequestedThreadId ?? string.Empty;
+
+			lock (this.synchObject)
+			{
+				string threadId = RequestedThreadId;
+
+				if (!string.IsNullOrEmpty(threadId))
+				{
+					this.currentThreadIdPerContact[BareJid] = threadId;
+					return threadId;
+				}
+
+				if (!IsContentMessage)
+					return string.Empty;
+
+				if (this.currentThreadIdPerContact.TryGetValue(BareJid, out string Current) &&
+					!this.endedThreads.Contains(ComposeThreadKey(BareJid, Current)))
+				{
+					return Current;
+				}
+
+				string NewThread;
+				do
+				{
+					NewThread = Guid.NewGuid().ToString("N");
+				}
+				while (this.endedThreads.Contains(ComposeThreadKey(BareJid, NewThread)));
+
+				this.currentThreadIdPerContact[BareJid] = NewThread;
+				return NewThread;
+			}
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatState.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatState.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Waher.Networking.XMPP.Chat.ChatStates
+{
+    /// <summary>
+    /// Specifies the possible states of a chat participant in a messaging conversation. XEP-0085 Chat State
+    /// </summary>
+    /// <remarks>These states indicate the participant's current activity, such as whether they are actively
+    /// engaged, composing a message, temporarily paused, inactive, or have left the conversation. The values are
+    /// typically used to provide real-time feedback to other participants in chat applications.</remarks>
+    public enum ChatState
+    {
+        /// <summary>
+        /// User is actively participating in the chat session.
+        /// </summary>
+        /// <remarks>User accepts an initial content message, sends a content message, gives focus to the chat session interface (perhaps after being inactive), or is otherwise paying attention to the conversation.</remarks>
+        Active,
+        /// <summary>
+        /// User is composing a message.
+        /// </summary>
+        /// <remarks>User is actively interacting with a message input interface specific to this chat session (e.g., by typing in the input area of a chat window).</remarks>
+        Composing,
+        /// <summary>
+        /// User had been composing but now has stopped.
+        /// </summary>
+        /// <remarks>User was composing but has not interacted with the message input interface for a short period of time (e.g., 30 seconds).</remarks>
+        Paused,
+        /// <summary>
+        /// User has not been actively participating in the chat session.
+        /// </summary>
+        /// <remarks>User has not interacted with the chat session interface for an intermediate period of time (e.g., 2 minutes).</remarks>
+        Inactive,
+        /// <summary>
+        /// User has effectively ended their participation in the chat session.
+        /// </summary>
+        /// <remarks>User has not interacted with the chat session interface, system, or device for a relatively long period of time (e.g., 10 minutes).</remarks>
+        Gone
+    }
+}

--- a/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatStateNegotiationState.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatStateNegotiationState.cs
@@ -1,0 +1,28 @@
+namespace Waher.Networking.XMPP.Chat.ChatStates
+{
+	/// <summary>
+	/// Negotiation state for chat state notifications.
+	/// </summary>
+	public enum ChatStateNegotiationState
+	{
+		/// <summary>
+		/// Unknown support state.
+		/// </summary>
+		Unknown = 0,
+
+		/// <summary>
+		/// Support requested.
+		/// </summary>
+		Requested = 1,
+
+		/// <summary>
+		/// Supported.
+		/// </summary>
+		Supported = 2,
+
+		/// <summary>
+		/// Not supported.
+		/// </summary>
+		NotSupported = 3
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatStateSupportDeterminedEventHandler.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/ChatStates/ChatStateSupportDeterminedEventHandler.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Waher.Networking.XMPP.Chat.ChatStates
+{
+	/// <summary>
+	/// Delegate invoked when chat state support has been determined for a contact.
+	/// </summary>
+	/// <param name="bareJid">Bare JID whose capability changed.</param>
+	/// <param name="supported">If the contact supports chat states.</param>
+	public delegate Task ChatStateSupportDeterminedEventHandler(string bareJid, bool supported);
+}

--- a/Networking/Waher.Networking.XMPP/Chat/Corrections/MessageCorrections.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/Corrections/MessageCorrections.cs
@@ -1,0 +1,13 @@
+namespace Waher.Networking.XMPP.Chat.Corrections
+{
+	/// <summary>
+	/// XEP-0308 Message Correction.
+	/// </summary>
+	public static class MessageCorrections
+	{
+		/// <summary>
+		/// urn:xmpp:message-correct:0
+		/// </summary>
+		public const string NamespaceMessageCorrection = "urn:xmpp:message-correct:0";
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/Markers/ChatMarkerType.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/Markers/ChatMarkerType.cs
@@ -1,0 +1,18 @@
+namespace Waher.Networking.XMPP.Chat.Markers
+{
+	/// <summary>
+	/// Chat marker types supported by XEP-0333 (Displayed Markers).
+	/// </summary>
+	public enum ChatMarkerType
+	{
+		/// <summary>
+		/// markable
+		/// </summary>
+		Markable = 0,
+
+		/// <summary>
+		/// displayed
+		/// </summary>
+		Displayed = 1
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/Markers/ChatMarkers.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/Markers/ChatMarkers.cs
@@ -1,0 +1,13 @@
+namespace Waher.Networking.XMPP.Chat.Markers
+{
+	/// <summary>
+	/// XEP-0333 Displayed Markers.
+	/// </summary>
+	public static class ChatMarkers
+	{
+		/// <summary>
+		/// urn:xmpp:chat-markers:0
+		/// </summary>
+		public const string NamespaceChatMarkers = "urn:xmpp:chat-markers:0";
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Chat/Receipts/DeliveryReceipts.cs
+++ b/Networking/Waher.Networking.XMPP/Chat/Receipts/DeliveryReceipts.cs
@@ -1,0 +1,13 @@
+namespace Waher.Networking.XMPP.Chat.Receipts
+{
+	/// <summary>
+	/// XEP-0184 Message Delivery Receipts.
+	/// </summary>
+	public static class DeliveryReceipts
+	{
+		/// <summary>
+		/// urn:xmpp:receipts
+		/// </summary>
+		public const string NamespaceDeliveryReceipts = "urn:xmpp:receipts";
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Events/ChatMarkerEventArgs.cs
+++ b/Networking/Waher.Networking.XMPP/Events/ChatMarkerEventArgs.cs
@@ -1,0 +1,55 @@
+using System;
+using Waher.Networking.XMPP;
+using Waher.Networking.XMPP.Chat.Markers;
+
+namespace Waher.Networking.XMPP.Events
+{
+	/// <summary>
+	/// Event arguments for chat markers (XEP-0333).
+	/// </summary>
+	public class ChatMarkerEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Creates event arguments for a chat marker.
+		/// </summary>
+		/// <param name="message">Message event.</param>
+		/// <param name="markerType">Marker type.</param>
+		/// <param name="id">Referenced stanza id.</param>
+		public ChatMarkerEventArgs(MessageEventArgs message, ChatMarkerType markerType, string id)
+		{
+			this.Message = message;
+			this.MarkerType = markerType;
+			this.Id = id ?? string.Empty;
+		}
+
+		/// <summary>
+		/// Message event associated with the marker.
+		/// </summary>
+		public MessageEventArgs Message { get; }
+
+		/// <summary>
+		/// Marker type.
+		/// </summary>
+		public ChatMarkerType MarkerType { get; }
+
+		/// <summary>
+		/// Referenced stanza id.
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// Message type.
+		/// </summary>
+		public MessageType MessageType => this.Message?.Type ?? MessageType.Normal;
+
+		/// <summary>
+		/// From JID.
+		/// </summary>
+		public string From => this.Message?.From;
+
+		/// <summary>
+		/// To JID.
+		/// </summary>
+		public string To => this.Message?.To;
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Events/ChatStateEventArgs.cs
+++ b/Networking/Waher.Networking.XMPP/Events/ChatStateEventArgs.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Waher.Networking.XMPP.Chat.ChatStates;
+
+namespace Waher.Networking.XMPP.Events
+{
+    /// <summary>
+    /// Provides data for events that report a change in chat state, such as when a user is typing or has paused typing.
+    /// </summary>
+    /// <remarks>Use this class with event handlers that need information about the current chat state and the
+    /// associated message event. The chat state indicates the user's activity in the chat, such as composing, paused,
+    /// or inactive.</remarks>
+	public class ChatStateEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Initializes a new instance of the ChatStateEventArgs class with the specified message and chat state.
+		/// </summary>
+		/// <param name="message">The message event data associated with the chat state change. Cannot be null.</param>
+		/// <param name="state">The new chat state represented by this event.</param>
+		/// <param name="previousState">The previous chat state observed for the same contact.</param>
+		public ChatStateEventArgs(MessageEventArgs message, ChatState state, ChatState previousState)
+		{
+			this.Message = message;
+			this.State = state;
+			this.PreviousState = previousState;
+		}
+
+		/// <summary>
+		/// Message event associated with the chat state change.
+		/// </summary>
+		public MessageEventArgs Message { get; }
+
+		/// <summary>
+		/// New chat state.
+		/// </summary>
+		public ChatState State { get; }
+
+		/// <summary>
+		/// Previous chat state tracked for the same bare JID.
+		/// </summary>
+		public ChatState PreviousState { get; }
+	}
+
+}

--- a/Networking/Waher.Networking.XMPP/Events/DeliveryReceiptEventArgs.cs
+++ b/Networking/Waher.Networking.XMPP/Events/DeliveryReceiptEventArgs.cs
@@ -1,0 +1,59 @@
+using System;
+using Waher.Networking.XMPP;
+
+namespace Waher.Networking.XMPP.Events
+{
+	/// <summary>
+	/// Event arguments for delivery receipt events (XEP-0184).
+	/// </summary>
+	public class DeliveryReceiptEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Creates event arguments for a receipt request or response.
+		/// </summary>
+		/// <param name="message">Message event.</param>
+		/// <param name="id">Referenced stanza id.</param>
+		/// <param name="isRequest">If this is a receipt request.</param>
+		public DeliveryReceiptEventArgs(MessageEventArgs message, string id, bool isRequest)
+		{
+			this.Message = message;
+			this.Id = id ?? string.Empty;
+			this.IsRequest = isRequest;
+		}
+
+		/// <summary>
+		/// Message event associated with the receipt.
+		/// </summary>
+		public MessageEventArgs Message { get; }
+
+		/// <summary>
+		/// Referenced stanza id.
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// If this event represents a receipt request.
+		/// </summary>
+		public bool IsRequest { get; }
+
+		/// <summary>
+		/// If this event represents a receipt response.
+		/// </summary>
+		public bool IsReceived => !this.IsRequest;
+
+		/// <summary>
+		/// Message type.
+		/// </summary>
+		public MessageType MessageType => this.Message?.Type ?? MessageType.Normal;
+
+		/// <summary>
+		/// From JID.
+		/// </summary>
+		public string From => this.Message?.From;
+
+		/// <summary>
+		/// To JID.
+		/// </summary>
+		public string To => this.Message?.To;
+	}
+}

--- a/Networking/Waher.Networking.XMPP/Events/MessageCorrectionEventArgs.cs
+++ b/Networking/Waher.Networking.XMPP/Events/MessageCorrectionEventArgs.cs
@@ -1,0 +1,61 @@
+using System;
+using Waher.Networking.XMPP;
+
+namespace Waher.Networking.XMPP.Events
+{
+	/// <summary>
+	/// Event arguments for message correction events (XEP-0308).
+	/// </summary>
+	public class MessageCorrectionEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Creates event arguments for a message correction.
+		/// </summary>
+		/// <param name="message">Message event.</param>
+		/// <param name="replaceId">Id of the stanza being replaced.</param>
+		/// <param name="newBody">Corrected body.</param>
+		/// <param name="newSubject">Corrected subject.</param>
+		public MessageCorrectionEventArgs(MessageEventArgs message, string replaceId, string newBody, string newSubject)
+		{
+			this.Message = message;
+			this.ReplaceId = replaceId ?? string.Empty;
+			this.NewBody = newBody ?? string.Empty;
+			this.NewSubject = newSubject ?? string.Empty;
+		}
+
+		/// <summary>
+		/// Message event associated with the correction.
+		/// </summary>
+		public MessageEventArgs Message { get; }
+
+		/// <summary>
+		/// Id of the stanza being replaced.
+		/// </summary>
+		public string ReplaceId { get; }
+
+		/// <summary>
+		/// Corrected body.
+		/// </summary>
+		public string NewBody { get; }
+
+		/// <summary>
+		/// Corrected subject.
+		/// </summary>
+		public string NewSubject { get; }
+
+		/// <summary>
+		/// Message type.
+		/// </summary>
+		public MessageType MessageType => this.Message?.Type ?? MessageType.Normal;
+
+		/// <summary>
+		/// From JID.
+		/// </summary>
+		public string From => this.Message?.From;
+
+		/// <summary>
+		/// To JID.
+		/// </summary>
+		public string To => this.Message?.To;
+	}
+}

--- a/Networking/Waher.Networking.XMPP/XmppClient.cs
+++ b/Networking/Waher.Networking.XMPP/XmppClient.cs
@@ -290,6 +290,7 @@ namespace Waher.Networking.XMPP
 		private bool? checkConnection = null;
 		private bool openBracketReceived = false;
 		private bool monitorContactResourcesAlive = true;
+		private bool autoRespondToDeliveryReceiptRequests = true;
 		private bool upgradeToTls = false;
 		private bool legacyTls = false;
 		private bool performingQuickLogin = false;
@@ -2339,6 +2340,9 @@ namespace Waher.Networking.XMPP
 						}
 						else if (E.LocalName == "request" && E.NamespaceURI == NamespaceMessageDeliveryReceipts && !string.IsNullOrEmpty(e.Id))
 						{
+							if (!this.autoRespondToDeliveryReceiptRequests)
+								continue;
+
 							RosterItem Item = this.GetRosterItemLocked(GetBareJID(e.To));
 							if (!(Item is null) && (Item.State == SubscriptionState.Both || Item.State == SubscriptionState.From))
 							{
@@ -7396,6 +7400,16 @@ namespace Waher.Networking.XMPP
 		{
 			get => this.sendFromAddress;
 			set => this.sendFromAddress = value;
+		}
+
+		/// <summary>
+		/// If delivery receipt requests (XEP-0184) should be auto-acknowledged.
+		/// Default is true.
+		/// </summary>
+		public bool AutoRespondToDeliveryReceiptRequests
+		{
+			get => this.autoRespondToDeliveryReceiptRequests;
+			set => this.autoRespondToDeliveryReceiptRequests = value;
 		}
 
 		/// <summary>


### PR DESCRIPTION
## PR: Add `ChatClient` (XEP-0085 / 0184 / 0333 / 0308)

### Summary

Adds a `ChatClient` extension that provides a chat-focused facade on top of `XmppClient`. It encapsulates common chat behaviors and XEP payload handling. An hook to listen to Message stanzas before handlers are called has been added to `XmppClient` 

Unit-tests has been added for each extension `ChatClient`implements

### Included features

* **XEP-0085: Chat State Notifications**

  * Handles incoming chat states: `active`, `composing`, `paused`, `inactive`, `gone`
  * Supports capability-based negotiation:

    * Uses entity capabilities from presence
    * Falls back to direct discovery when capabilities are missing
  * Suppresses standalone `<active/>`and embeds `<active/>` in content messages when appropriate

* **XEP-0184: Message Delivery Receipts**

  * Supports sending receipt requests
  * Parses `<received/>` receipts
  * Optional auto-respond to incoming receipt requests (excluding delayed messages)

* **XEP-0333: Chat Markers**

  * Supports sending `<markable/>`
  * Parses `<displayed/>` markers
  * Optional auto-send displayed markers for incoming markable messages (excluding delayed messages)

* **XEP-0308: Last Message Corrections**

  * Supports sending corrections using `<replace id='...'/>`
  * Parses incoming message corrections and raises a dedicated event
  
### Planned features
  
  *  **XEP-0444: Message Reactions**
  *  **XEP-0461: Message Replies**

### Thread handling

* Tracks thread IDs per contact and reuses active thread IDs for outgoing content messages.
* Generates a new thread ID for a contact when sending content and no valid current thread exists.
* Marks threads as ended when receiving/sending `gone` for 1:1 chats and prevents reuse.

### Details

* Handles delayed delivery (`urn:xmpp:delay` and `jabber:x:delay`) and avoids auto-replies (receipts/markers) for delayed messages.
* Resets internal caches and negotiation state on disconnect (`Offline` / `Error`).
* Prevents duplicate standalone chat-state sends per contact/thread.
* Service discovery requests are deduped and cached to avoid repeated disco calls.
* Fire-and-forget async tasks are observed/logged to avoid silent failures.

### Public API

* Enable flags for each supported XEP:

  * `EnableChatStateNotifications`
  * `EnableDeliveryReceipts`
  * `EnableChatMarkers`
  * `EnableMessageCorrection`
* Auto behaviors:

  * `AutoRespondToReceiptRequests`
  * `AutoSendDisplayedMarkers`
* Events:

  * `OnChatStateChanged` (+ per-state events)
  * `OnChatStateSupportDetermined`
  * `OnReceiptRequest` / `OnReceiptReceived`
  * `OnChatMarker`
  * `OnMessageCorrected`
* Send helpers:

  * chat messages (with/without receipt requests / markable)
  * chat state sends
  * displayed markers
  * message corrections

### Notes

This is a protocol-level facade. It does not include storage, UI session management, or any higher level abstractions.
But,
A future version of `ChatClient` is planned to introduce a lightweight **`ChatSession`** abstraction to make application-level chat handling simpler without changing the protocol layer.

A `ChatSession` represents **1 1:1 conversation** and will:

* Be created via

  ```csharp
  var session = chatClient.With("user@example.com");
  ```

* Provide a **single update stream** (`OnUpdate`) that combines:

  * incoming messages
  * typing states
  * receipts
  * markers (read)
  * message corrections

* Provide **one-line send APIs** such as:

  ```csharp
  session.SendTextAsync("Hello");
  session.SetTypingAsync(true);
  session.CorrectAsync(oldId, "Fixed text");
  ```

Internally, `ChatSession` will just be a thin, per-JID facade over `ChatClient`:

* No separate networking
* No extra threads
* No duplication of state
  It will simply route and filter `ChatClient`’s existing protocol events and send methods.

This keeps `ChatClient` as the **protocol-correct XMPP implementation**, while `ChatSession` becomes the **developer-friendly conversation view** used by UIs and services.

--- 

Currently this is focused on 1:1 chats. I have not yet found a satisfying answer to XEP-0045: Multi-User Chat as we already have a client for MUC. I propose MUC should be either integrated into ChatClient or we find a composable solution where ChatClient is an optional dependency in the MUC client.
I lean more towards a more unified solution, to make it easier for developers, but we'll take that discussion when we need it, I just wanted to make a note of this.

ChatClient should nevertheless be compliant in regards to it's extensions and handling of groupchat messages.
