### PR TITLE
Add safe-guard GenerateNewKeys corrupting local legal-identity key state and add safe preflight API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ Temporary Items
 
 # Non distributable third party downloads
 Utilities\PsExec.exe
+
+# C# dev kit cache files
+*.lscache

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractSharedSecretState.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractSharedSecretState.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Text;
+using Waher.Networking.XMPP.P2P.SymmetricCiphers;
+using Waher.Persistence;
+using Waher.Persistence.Attributes;
+using Waher.Runtime.Collections;
+using Waher.Runtime.Inventory;
+using Waher.Security.CallStack;
+
+namespace Waher.Networking.XMPP.Contracts
+{
+	/// <summary>
+	/// Contains a persisted shared secret associated with a smart contract.
+	/// </summary>
+	[CollectionName("ContractSharedSecretStates")]
+	[TypeName(TypeNameSerialization.None)]
+	[Index("BareJid", "ContractId")]
+	public class ContractSharedSecretState : IEncryptedProperties
+	{
+		private static ICallStackCheck[] approvedSources = null;
+
+		private string objectId = null;
+		private CaseInsensitiveString bareJid = CaseInsensitiveString.Empty;
+		private string contractId = string.Empty;
+		private string creatorJid = string.Empty;
+		private SymmetricCipherAlgorithms keyAlgorithm = SymmetricCipherAlgorithms.Aes256;
+		private byte[] sharedSecret = null;
+
+		/// <summary>
+		/// Contains a persisted shared secret associated with a smart contract.
+		/// </summary>
+		public ContractSharedSecretState()
+		{
+		}
+
+		/// <summary>
+		/// Contains a persisted shared secret associated with a smart contract.
+		/// </summary>
+		/// <param name="ContractId">Contract ID.</param>
+		public ContractSharedSecretState(string ContractId)
+		{
+			this.contractId = ContractId;
+		}
+
+		/// <summary>
+		/// Object ID.
+		/// </summary>
+		[ObjectId]
+		public string ObjectId
+		{
+			get => this.objectId;
+			set => this.objectId = value;
+		}
+
+		/// <summary>
+		/// Bare JID of the client owning the contract state.
+		/// </summary>
+		public CaseInsensitiveString BareJid
+		{
+			get => this.bareJid;
+			set => this.bareJid = value;
+		}
+
+		/// <summary>
+		/// Contract ID.
+		/// </summary>
+		public string ContractId
+		{
+			get => this.contractId;
+			set => this.contractId = value;
+		}
+
+		/// <summary>
+		/// Bare JID of the contract creator.
+		/// </summary>
+		[DefaultValueStringEmpty]
+		public string CreatorJid
+		{
+			get => this.creatorJid;
+			set => this.creatorJid = value;
+		}
+
+		/// <summary>
+		/// Symmetric encryption algorithm used with the shared secret.
+		/// </summary>
+		public SymmetricCipherAlgorithms KeyAlgorithm
+		{
+			get => this.keyAlgorithm;
+			set => this.keyAlgorithm = value;
+		}
+
+		/// <summary>
+		/// If a shared secret snapshot is available for the contract.
+		/// </summary>
+		public bool HasSharedSecret => !(this.sharedSecret is null);
+
+		/// <summary>
+		/// Shared secret snapshot stored with the contract state.
+		/// </summary>
+		[DefaultValueNull]
+		[Encrypted(32)]
+		public byte[] SharedSecret
+		{
+			get
+			{
+				AssertAllowed();
+				return this.sharedSecret;
+			}
+
+			set
+			{
+				if (!(this.sharedSecret is null))
+					AssertAllowed();
+
+				this.sharedSecret = value;
+			}
+		}
+
+		/// <summary>
+		/// Array of properties that are encrypted.
+		/// </summary>
+		public string[] EncryptedProperties => new string[]
+		{
+			nameof(this.SharedSecret)
+		};
+
+		/// <summary>
+		/// If access to sensitive properties is only accessible from a set of approved sources.
+		/// </summary>
+		/// <param name="ApprovedSources">Approved sources.</param>
+		/// <exception cref="NotSupportedException">If trying to change previously set sources.</exception>
+		public static void SetAllowedSources(ICallStackCheck[] ApprovedSources)
+		{
+			if (!(approvedSources is null))
+				throw new NotSupportedException("Changing approved sources not permitted.");
+
+			approvedSources = ApprovedSources;
+		}
+
+		private static void AssertAllowed()
+		{
+			if (!(approvedSources is null))
+				Assert.CallFromSource(approvedSources);
+		}
+
+		/// <inheritdoc/>
+		public override string ToString()
+		{
+			StringBuilder sb = new StringBuilder();
+
+			sb.Append(this.bareJid);
+			sb.Append(", ");
+			sb.Append(this.contractId);
+			sb.Append(", ");
+			sb.Append(this.creatorJid);
+			sb.Append(", ");
+			sb.Append(this.keyAlgorithm.ToString());
+
+			if (!(this.sharedSecret is null))
+				sb.Append(", SharedSecret");
+
+			return sb.ToString();
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -537,7 +537,15 @@ namespace Waher.Networking.XMPP.Contracts
 						if (this.client.TryGetTag("E2E", out object Obj) &&
 							Obj is EndpointSecurity EndpointSecurity)
 						{
-							this.localKeys = EndpointSecurity;
+							if (MatchesLoadedKeys(EndpointSecurity, Keys))
+								this.localKeys = EndpointSecurity;
+							else
+							{
+								this.localKeys = new EndpointSecurity(this.client, 128, Keys.ToArray());
+								this.client.SetTag("E2E", this.localKeys);
+								this.disposeLocalKeys = true;
+								EndpointSecurity.Dispose();
+							}
 						}
 						else
 						{
@@ -712,6 +720,22 @@ namespace Waher.Networking.XMPP.Contracts
 			return !(PrivateKey is null);
 		}
 
+		private static bool MatchesLoadedKeys(EndpointSecurity EndpointSecurity, IEnumerable<IE2eEndpoint> Keys)
+		{
+			if (EndpointSecurity is null)
+				return false;
+
+			foreach (IE2eEndpoint Key in Keys)
+			{
+				IE2eEndpoint ExistingEndpoint = EndpointSecurity.FindLocalEndpoint(Key.LocalName, Key.Namespace);
+
+				if (ExistingEndpoint is null || !AreEqual(ExistingEndpoint.PublicKey, Key.PublicKey))
+					return false;
+			}
+
+			return true;
+		}
+
 		private async Task<Tuple<string, string, byte[]>> GetPersistablePrivateKeyAsync(IE2eEndpoint Endpoint)
 		{
 			if (Endpoint is null)
@@ -725,11 +749,21 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				try
 				{
-					return new Tuple<string, string, byte[]>(KeyName, KeyNamespace, Convert.FromBase64String(RuntimeValue));
+					byte[] RuntimePrivateKey = Convert.FromBase64String(RuntimeValue);
+
+					if (EndpointSecurity.TryCreateEndpoint(KeyName, KeyNamespace, out IE2eEndpoint Template))
+					{
+						using (Template)
+						using (IE2eEndpoint RuntimeEndpoint = Template.CreatePrivate(RuntimePrivateKey))
+						{
+							if (AreEqual(RuntimeEndpoint.PublicKey, Endpoint.PublicKey))
+								return new Tuple<string, string, byte[]>(KeyName, KeyNamespace, RuntimePrivateKey);
+						}
+					}
 				}
 				catch (Exception)
 				{
-					// Ignore malformed runtime value and fall back to endpoint export.
+					// Ignore malformed or mismatched runtime values and fall back to endpoint export.
 				}
 			}
 

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -206,6 +206,7 @@ namespace Waher.Networking.XMPP.Contracts
 		{
 			this.componentAddress = ComponentAddress;
 			this.approvedSources = ApprovedSources;
+			this.SetLegalIdentityStateAllowedSources(ApprovedSources);
 			this.localKeys = null;
 			this.disposeLocalKeys = false;
 
@@ -568,44 +569,15 @@ namespace Waher.Networking.XMPP.Contracts
 		}
 
 		/// <summary>
-		/// Checks whether new keys can be generated without leaving locally tracked created or approved legal identities
-		/// without matching private keys on the current device.
-		/// </summary>
-		/// <returns>If new keys can be generated safely.</returns>
-		public async Task<bool> CanGenerateNewKeys()
-		{
-			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(false);
-			return await this.CanGenerateNewKeysAsync(ActiveStates);
-		}
-
-		/// <summary>
 		/// Generates new keys for the contracts clients.
 		/// </summary>
 		public async Task GenerateNewKeys()
 		{
-			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(true);
-
-			if (!await this.CanGenerateNewKeysAsync(ActiveStates))
-			{
-				throw new InvalidOperationException("Cannot generate new keys while created or approved legal identities exist and their private keys are unavailable on this device.");
-			}
+			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(false);
 
 			foreach (LegalIdentityState State in ActiveStates)
 			{
-				try
-				{
-					LegalIdentity Identity = await this.ObsoleteLegalIdentityAsync(State.LegalId);
-					await this.UpdateSettings(Identity);
-				}
-				catch (ItemNotFoundException)
-				{
-					await Database.Delete(State);
-				}
-				catch (Exception ex)
-				{
-					Log.Exception(ex, State.LegalId);
-					throw;
-				}
+				await this.TryGetLegalIdentityEndpointAsync(State, true);
 			}
 
 			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
@@ -670,9 +642,168 @@ namespace Waher.Networking.XMPP.Contracts
 			return ActiveStates;
 		}
 
-		private async Task<bool> CanGenerateNewKeysAsync(ICollection<LegalIdentityState> ActiveStates)
+		private static byte[] Clone(byte[] Bin)
 		{
-			return ActiveStates.Count == 0 || await this.LoadKeys(false);
+			return Bin is null ? null : (byte[])Bin.Clone();
+		}
+
+		private static bool AreEqual(byte[] A, byte[] B)
+		{
+			if (ReferenceEquals(A, B))
+				return true;
+
+			if (A is null || B is null || A.Length != B.Length)
+				return false;
+
+			int i, c = A.Length;
+
+			for (i = 0; i < c; i++)
+			{
+				if (A[i] != B[i])
+					return false;
+			}
+
+			return true;
+		}
+
+		private bool TryExportPrivateKey(IE2eEndpoint Endpoint, out string KeyName, out string KeyNamespace, out byte[] PrivateKey)
+		{
+			KeyName = Endpoint?.LocalName;
+			KeyNamespace = Endpoint?.Namespace;
+			PrivateKey = null;
+
+			switch (Endpoint)
+			{
+				case EllipticCurveEndpoint Curve:
+					PrivateKey = this.GetKey(Curve);
+					break;
+
+				case ModuleLatticeEndpoint ModuleLattice:
+					PrivateKey = ModuleLattice.ExportPrivateKey();
+					break;
+
+				case RsaEndpoint Rsa:
+					PrivateKey = Rsa.Export(true);
+					break;
+
+				default:
+					return false;
+			}
+
+			return !(PrivateKey is null);
+		}
+
+		private async Task<Tuple<string, string, byte[]>> GetPersistablePrivateKeyAsync(IE2eEndpoint Endpoint)
+		{
+			if (Endpoint is null)
+				return null;
+
+			string KeyName = Endpoint.LocalName;
+			string KeyNamespace = Endpoint.Namespace;
+			string RuntimeValue = await RuntimeSettings.GetAsync(this.keySettingsPrefix + KeyName, string.Empty);
+
+			if (!string.IsNullOrEmpty(RuntimeValue))
+			{
+				try
+				{
+					return new Tuple<string, string, byte[]>(KeyName, KeyNamespace, Convert.FromBase64String(RuntimeValue));
+				}
+				catch (Exception)
+				{
+					// Ignore malformed runtime value and fall back to endpoint export.
+				}
+			}
+
+			return this.TryExportPrivateKey(Endpoint, out KeyName, out KeyNamespace, out byte[] PrivateKey) ?
+				new Tuple<string, string, byte[]>(KeyName, KeyNamespace, PrivateKey)
+				: null;
+		}
+
+		private IE2eEndpoint TryCreateLegalIdentityEndpoint(LegalIdentityState State)
+		{
+			if (State is null || !State.HasPrivateKey || string.IsNullOrEmpty(State.KeyName))
+				return null;
+
+			string KeyNamespace = string.IsNullOrEmpty(State.KeyNamespace) ? EndpointSecurity.IoTHarmonizationE2ECurrent : State.KeyNamespace;
+			byte[] PrivateKey = State.PrivateKey;
+
+			if (PrivateKey is null || !EndpointSecurity.TryCreateEndpoint(State.KeyName, KeyNamespace, out IE2eEndpoint Template))
+				return null;
+
+			try
+			{
+				return Template.CreatePrivate(PrivateKey);
+			}
+			catch (Exception ex)
+			{
+				Log.Exception(ex, State.LegalId);
+				return null;
+			}
+		}
+
+		private async Task<bool> SetLegalIdentityKeySnapshotAsync(LegalIdentityState State, IE2eEndpoint Endpoint)
+		{
+			Tuple<string, string, byte[]> P = State is null ? null : await this.GetPersistablePrivateKeyAsync(Endpoint);
+
+			if (P is null)
+			{
+				return false;
+			}
+
+			string KeyName = P.Item1;
+			string KeyNamespace = P.Item2;
+			byte[] PrivateKey = P.Item3;
+
+			bool Updated = !AreEqual(State.PublicKey, Endpoint.PublicKey) ||
+				State.KeyName != KeyName ||
+				State.KeyNamespace != KeyNamespace ||
+				!AreEqual(State.HasPrivateKey ? State.PrivateKey : null, PrivateKey);
+
+			State.PublicKey = Clone(Endpoint.PublicKey);
+			State.KeyName = KeyName;
+			State.KeyNamespace = KeyNamespace;
+			State.PrivateKey = Clone(PrivateKey);
+
+			return Updated;
+		}
+
+		private async Task<Tuple<IE2eEndpoint, bool>> TryGetLegalIdentityEndpointAsync(LegalIdentityState State, bool MigrateLegacyState)
+		{
+			IE2eEndpoint Endpoint = this.TryCreateLegalIdentityEndpoint(State);
+
+			if (!(Endpoint is null))
+			{
+				if (State.PublicKey is null)
+				{
+					State.PublicKey = Clone(Endpoint.PublicKey);
+					if (!string.IsNullOrEmpty(State.ObjectId))
+						await Database.Update(State);
+
+					return new Tuple<IE2eEndpoint, bool>(Endpoint, true);
+				}
+				else if (!AreEqual(State.PublicKey, Endpoint.PublicKey))
+				{
+					Endpoint.Dispose();
+					Endpoint = null;
+				}
+				else
+					return new Tuple<IE2eEndpoint, bool>(Endpoint, true);
+			}
+
+			if (!MigrateLegacyState || State?.PublicKey is null || !await this.LoadKeys(false))
+				return new Tuple<IE2eEndpoint, bool>(null, false);
+
+			Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
+			if (Endpoint is null || !await this.SetLegalIdentityKeySnapshotAsync(State, Endpoint))
+				return new Tuple<IE2eEndpoint, bool>(Endpoint, false);
+
+			if (!string.IsNullOrEmpty(State.ObjectId))
+				await Database.Update(State);
+
+			IE2eEndpoint Endpoint2 = this.TryCreateLegalIdentityEndpoint(State);
+			return Endpoint2 is null ?
+				new Tuple<IE2eEndpoint, bool>(Endpoint, false)
+				: new Tuple<IE2eEndpoint, bool>(Endpoint2, true);
 		}
 
 		/// <summary>
@@ -702,8 +833,6 @@ namespace Waher.Networking.XMPP.Contracts
 
 			Output.WriteStartElement("LegalId", NamespaceOnboarding);
 
-			bool KeysLoaded = await this.LoadKeys(false);
-
 			Dictionary<string, object> Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
 
 			foreach (KeyValuePair<string, object> Setting in Settings)
@@ -730,14 +859,32 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved))))
 			{
-				if (!KeysLoaded || State.PublicKey is null || this.LocalEndpoint.FindLocalEndpoint(State.PublicKey) is null)
+				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
+				IE2eEndpoint Endpoint = P.Item1;
+
+				if (Endpoint is null || State.PublicKey is null || !State.HasPrivateKey || string.IsNullOrEmpty(State.KeyName))
 					continue;
 
-				Output.WriteStartElement("State");
-				Output.WriteAttributeString("legalId", State.LegalId);
-				Output.WriteAttributeString("publicKey", Convert.ToBase64String(State.PublicKey));
-				Output.WriteAttributeString("timestamp", XML.Encode(State.Timestamp));
-				Output.WriteEndElement();
+				try
+				{
+					Output.WriteStartElement("State");
+					Output.WriteAttributeString("legalId", State.LegalId);
+					Output.WriteAttributeString("publicKey", Convert.ToBase64String(State.PublicKey));
+					Output.WriteAttributeString("timestamp", XML.Encode(State.Timestamp));
+					Output.WriteAttributeString("keyName", State.KeyName);
+
+					if (!string.IsNullOrEmpty(State.KeyNamespace))
+						Output.WriteAttributeString("keyNamespace", State.KeyNamespace);
+
+					Output.WriteAttributeString("hasPrivateKey", CommonTypes.Encode(State.HasPrivateKey));
+					Output.WriteAttributeString("privateKey", Convert.ToBase64String(State.PrivateKey));
+					Output.WriteEndElement();
+				}
+				finally
+				{
+					if (P.Item2)
+						Endpoint.Dispose();
+				}
 			}
 
 			Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.contractKeySettingsPrefix + "*", "*");
@@ -826,7 +973,11 @@ namespace Waher.Networking.XMPP.Contracts
 					case "State":
 						string LegalId = XML.Attribute(E, "legalId");
 						string PublicKeyStr = XML.Attribute(E, "publicKey");
+						string PrivateKeyStr = XML.Attribute(E, "privateKey");
+						string KeyName = XML.Attribute(E, "keyName");
+						string KeyNamespace = XML.Attribute(E, "keyNamespace");
 						byte[] PublicKey;
+						byte[] PrivateKey = null;
 						DateTimeValue = XML.Attribute(E, "timestamp", DateTime.MinValue);
 
 						try
@@ -836,6 +987,18 @@ namespace Waher.Networking.XMPP.Contracts
 						catch (Exception)
 						{
 							return false;
+						}
+
+						if (!string.IsNullOrEmpty(PrivateKeyStr))
+						{
+							try
+							{
+								PrivateKey = Convert.FromBase64String(PrivateKeyStr);
+							}
+							catch (Exception)
+							{
+								return false;
+							}
 						}
 
 						LegalIdentityState IdState = await Database.FindFirstDeleteRest<LegalIdentityState>(new FilterAnd(
@@ -850,7 +1013,10 @@ namespace Waher.Networking.XMPP.Contracts
 								LegalId = LegalId,
 								State = IdentityState.Approved,
 								Timestamp = DateTimeValue,
-								PublicKey = PublicKey
+								PublicKey = PublicKey,
+								KeyName = KeyName,
+								KeyNamespace = KeyNamespace,
+								PrivateKey = PrivateKey
 							};
 
 							await Database.Insert(IdState);
@@ -860,6 +1026,9 @@ namespace Waher.Networking.XMPP.Contracts
 							IdState.State = IdentityState.Approved;
 							IdState.Timestamp = DateTimeValue;
 							IdState.PublicKey = PublicKey;
+							IdState.KeyName = KeyName;
+							IdState.KeyNamespace = KeyNamespace;
+							IdState.PrivateKey = PrivateKey;
 
 							await Database.Update(IdState);
 						}
@@ -1041,12 +1210,28 @@ namespace Waher.Networking.XMPP.Contracts
 				throw new NotSupportedException("Changing approved sources not permitted.");
 
 			this.approvedSources = ApprovedSources;
+			this.SetLegalIdentityStateAllowedSources(ApprovedSources);
 		}
 
 		private void AssertAllowed()
 		{
 			if (!(this.approvedSources is null))
 				Assert.CallFromSource(this.approvedSources);
+		}
+
+		private void SetLegalIdentityStateAllowedSources(ICallStackCheck[] ApprovedSources)
+		{
+			if (ApprovedSources is null)
+				return;
+
+			try
+			{
+				LegalIdentityState.SetAllowedSources(ApprovedSources);
+			}
+			catch (NotSupportedException)
+			{
+				// Sensitive state access has already been configured globally.
+			}
 		}
 
 		#endregion
@@ -2293,12 +2478,17 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("LegalId", IdentityId)));
 
-			if (State?.PublicKey is null)
-				return false;
+			Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
 
-			IE2eEndpoint Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
-
-			return !(Endpoint is null);
+			try
+			{
+				return !(P.Item1 is null);
+			}
+			finally
+			{
+				if (P.Item2)
+					P.Item1?.Dispose();
+			}
 		}
 
 		/// <summary>
@@ -2323,23 +2513,29 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved)), "-Timestamp"))
 			{
-				if (State.PublicKey is null)
-					continue;
+				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
 
-				if (!(PublicKey is null) && Convert.ToBase64String(State.PublicKey) != PublicKeyBase64)
-					continue;
+				try
+				{
+					if (P.Item1 is null || State.PublicKey is null)
+						continue;
 
-				IE2eEndpoint Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
-				if (Endpoint is null)
-					continue;
+					if (!(PublicKey is null) && Convert.ToBase64String(State.PublicKey) != PublicKeyBase64)
+						continue;
 
-				return State.LegalId;
+					return State.LegalId;
+				}
+				finally
+				{
+					if (P.Item2)
+						P.Item1?.Dispose();
+				}
 			}
 
 			return null;
 		}
 
-		private async Task<IE2eEndpoint> GetLatestApprovedKey(bool ExceptionIfNone)
+		private async Task<Tuple<IE2eEndpoint, bool>> GetLatestApprovedKey(bool ExceptionIfNone)
 		{
 			bool HaveStates = false;
 
@@ -2349,14 +2545,9 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				HaveStates = true;
 
-				if (State.PublicKey is null)
-					continue;
-
-				IE2eEndpoint Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
-				if (Endpoint is null)
-					continue;
-
-				return Endpoint;
+				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
+				if (!(P.Item1 is null))
+					return P;
 			}
 
 			if (ExceptionIfNone)
@@ -2368,6 +2559,22 @@ namespace Waher.Networking.XMPP.Contracts
 				}
 				else
 					throw new Exception("No approved legal identity available on this device (" + this.client.BareJID + ").");
+			}
+
+			return new Tuple<IE2eEndpoint, bool>(null, false);
+		}
+
+		private async Task<LegalIdentityState> FindPreviewStateAsync(byte[] PublicKey, string LegalId)
+		{
+			if (PublicKey is null)
+				return null;
+
+			foreach (LegalIdentityState State in await Database.Find<LegalIdentityState>(new FilterAnd(
+				new FilterFieldEqualTo("BareJid", this.client.BareJID),
+				new FilterFieldEqualTo("State", IdentityState.Created))))
+			{
+				if (State.LegalId != LegalId && AreEqual(State.PublicKey, PublicKey))
+					return State;
 			}
 
 			return null;
@@ -2386,7 +2593,20 @@ namespace Waher.Networking.XMPP.Contracts
 						new FilterFieldEqualTo("LegalId", Identity.Id)));
 
 					if (StateObj2 is null)
-						StateObj.BareJid = this.client.BareJID;
+					{
+						StateObj2 = await this.FindPreviewStateAsync(PublicKey, Identity.Id);
+						if (StateObj2 is null)
+							StateObj.BareJid = this.client.BareJID;
+						else
+						{
+							if (!string.IsNullOrEmpty(StateObj2.LegalId))
+								Types.UnregisterSingleton(StateObj2, StateObj2.LegalId);
+
+							StateObj2.LegalId = Identity.Id;
+							Types.ReplaceSingleton(StateObj2, Identity.Id);
+							StateObj = StateObj2;
+						}
+					}
 					else
 					{
 						Types.ReplaceSingleton(StateObj2, Identity.Id);
@@ -2398,6 +2618,8 @@ namespace Waher.Networking.XMPP.Contracts
 
 				if (Timestamp > StateObj.Timestamp ||
 					(StateObj.PublicKey is null && !(PublicKey is null)) ||
+					(!StateObj.HasPrivateKey && !(PublicKey is null)) ||
+					(string.IsNullOrEmpty(StateObj.KeyName) && !(PublicKey is null)) ||
 					Identity.State > StateObj.State)
 				{
 					StateObj.State = Identity.State;
@@ -2415,7 +2637,19 @@ namespace Waher.Networking.XMPP.Contracts
 						}
 					}
 					else
-						StateObj.PublicKey = PublicKey;
+					{
+						if (await this.LoadKeys(false))
+						{
+							IE2eEndpoint Endpoint = this.LocalEndpoint.FindLocalEndpoint(PublicKey);
+
+							if (!(Endpoint is null))
+								await this.SetLegalIdentityKeySnapshotAsync(StateObj, Endpoint);
+							else
+								StateObj.PublicKey = Clone(PublicKey);
+						}
+						else
+							StateObj.PublicKey = Clone(PublicKey);
+					}
 
 					if (string.IsNullOrEmpty(StateObj.ObjectId))
 						await Database.Insert(StateObj);
@@ -2787,12 +3021,13 @@ namespace Waher.Networking.XMPP.Contracts
 			this.AssertAllowed();
 
 			byte[] Signature = null;
-			IE2eEndpoint Key = SignWith switch
+			Tuple<IE2eEndpoint, bool> P = SignWith switch
 			{
-				SignWith.CurrentKeys => null,
+				SignWith.CurrentKeys => new Tuple<IE2eEndpoint, bool>(null, false),
 				SignWith.LatestApprovedId => await this.GetLatestApprovedKey(true),
 				_ => await this.GetLatestApprovedKey(false),
 			};
+			IE2eEndpoint Key = P.Item1;
 
 			if (Key is null)
 			{
@@ -2807,9 +3042,17 @@ namespace Waher.Networking.XMPP.Contracts
 			}
 			else
 			{
-				Signature = Key.Sign(Data);
+				try
+				{
+					Signature = Key.Sign(Data);
 
-				await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
+					await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
+				}
+				finally
+				{
+					if (P.Item2)
+						Key.Dispose();
+				}
 			}
 		}
 
@@ -2873,7 +3116,10 @@ namespace Waher.Networking.XMPP.Contracts
 		{
 			this.AssertAllowed();
 
-			IE2eEndpoint Key = SignWith == SignWith.CurrentKeys ? null : await this.GetLatestApprovedKey(true);
+			Tuple<IE2eEndpoint, bool> P = SignWith == SignWith.CurrentKeys ?
+				new Tuple<IE2eEndpoint, bool>(null, false)
+				: await this.GetLatestApprovedKey(true);
+			IE2eEndpoint Key = P.Item1;
 			byte[] Signature = null;
 
 			if (Key is null)
@@ -2889,9 +3135,17 @@ namespace Waher.Networking.XMPP.Contracts
 			}
 			else
 			{
-				Signature = Key.Sign(Data);
+				try
+				{
+					Signature = Key.Sign(Data);
 
-				await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
+					await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
+				}
+				finally
+				{
+					if (P.Item2)
+						Key.Dispose();
+				}
 			}
 		}
 

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -809,7 +809,9 @@ namespace Waher.Networking.XMPP.Contracts
 					return new ResolvedLegalIdentityKey(Endpoint, true);
 			}
 
-			if (!MigrateLegacyState || State?.PublicKey is null || !await this.LoadKeys(false))
+			bool MissingSnapshot = State?.HasPrivateKey != true || string.IsNullOrEmpty(State.KeyName);
+
+			if (!MigrateLegacyState || !MissingSnapshot || State?.PublicKey is null || !await this.LoadKeys(false))
 				return new ResolvedLegalIdentityKey(null, false);
 
 			Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
@@ -1050,7 +1052,20 @@ namespace Waher.Networking.XMPP.Contracts
 				}
 			}
 
-			return await this.LoadKeys(false);
+			if (await this.LoadKeys(false))
+				return true;
+
+			foreach (LegalIdentityState State in await Database.Find<LegalIdentityState>(new FilterAnd(
+				new FilterFieldEqualTo("BareJid", this.client.BareJID),
+				new FilterFieldEqualTo("State", IdentityState.Approved))))
+			{
+				using ResolvedLegalIdentityKey Key = await this.TryGetLegalIdentityEndpointAsync(State, true);
+
+				if (!(Key.Endpoint is null))
+					return true;
+			}
+
+			return false;
 		}
 
 		/// <summary>

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -568,10 +568,46 @@ namespace Waher.Networking.XMPP.Contracts
 		}
 
 		/// <summary>
+		/// Checks whether new keys can be generated without leaving locally tracked created or approved legal identities
+		/// without matching private keys on the current device.
+		/// </summary>
+		/// <returns>If new keys can be generated safely.</returns>
+		public async Task<bool> CanGenerateNewKeys()
+		{
+			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(false);
+			return await this.CanGenerateNewKeysAsync(ActiveStates);
+		}
+
+		/// <summary>
 		/// Generates new keys for the contracts clients.
 		/// </summary>
 		public async Task GenerateNewKeys()
 		{
+			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(true);
+
+			if (!await this.CanGenerateNewKeysAsync(ActiveStates))
+			{
+				throw new InvalidOperationException("Cannot generate new keys while created or approved legal identities exist and their private keys are unavailable on this device.");
+			}
+
+			foreach (LegalIdentityState State in ActiveStates)
+			{
+				try
+				{
+					LegalIdentity Identity = await this.ObsoleteLegalIdentityAsync(State.LegalId);
+					await this.UpdateSettings(Identity);
+				}
+				catch (ItemNotFoundException)
+				{
+					await Database.Delete(State);
+				}
+				catch (Exception ex)
+				{
+					Log.Exception(ex, State.LegalId);
+					throw;
+				}
+			}
+
 			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
 			await this.LoadKeys(true);
 
@@ -579,17 +615,20 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				this.matchingKeys.Clear();
 			}
+		}
+
+		private async Task<List<LegalIdentityState>> GetActiveLegalIdentityStatesAsync(bool RefreshStates)
+		{
+			List<LegalIdentityState> ActiveStates = new List<LegalIdentityState>();
 
 			foreach (LegalIdentityState State in await Database.Find<LegalIdentityState>(
 				new FilterFieldEqualTo("BareJid", this.client.BareJID)))
 			{
-				LegalIdentity Identity;
-
-				if (State.State == IdentityState.Created || State.State == IdentityState.Approved)
+				if (RefreshStates && (State.State == IdentityState.Created || State.State == IdentityState.Approved))
 				{
 					try
 					{
-						Identity = await this.GetLegalIdentityAsync(State.LegalId);   // Make sure we have the latest.
+						LegalIdentity Identity = await this.GetLegalIdentityAsync(State.LegalId);   // Make sure we have the latest.
 						if (Identity.State != State.State)
 						{
 							State.State = Identity.State;
@@ -615,6 +654,7 @@ namespace Waher.Networking.XMPP.Contracts
 					catch (Exception ex)
 					{
 						Log.Exception(ex, State.LegalId);
+						throw;
 					}
 				}
 
@@ -622,22 +662,17 @@ namespace Waher.Networking.XMPP.Contracts
 				{
 					case IdentityState.Created:
 					case IdentityState.Approved:
-						try
-						{
-							Identity = await this.ObsoleteLegalIdentityAsync(State.LegalId);
-							await this.UpdateSettings(Identity);
-						}
-						catch (ItemNotFoundException)
-						{
-							await Database.Delete(State);
-						}
-						catch (Exception ex)
-						{
-							Log.Exception(ex, State.LegalId);
-						}
+						ActiveStates.Add(State);
 						break;
 				}
 			}
+
+			return ActiveStates;
+		}
+
+		private async Task<bool> CanGenerateNewKeysAsync(ICollection<LegalIdentityState> ActiveStates)
+		{
+			return ActiveStates.Count == 0 || await this.LoadKeys(false);
 		}
 
 		/// <summary>
@@ -667,6 +702,8 @@ namespace Waher.Networking.XMPP.Contracts
 
 			Output.WriteStartElement("LegalId", NamespaceOnboarding);
 
+			bool KeysLoaded = await this.LoadKeys(false);
+
 			Dictionary<string, object> Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
 
 			foreach (KeyValuePair<string, object> Setting in Settings)
@@ -693,6 +730,9 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved))))
 			{
+				if (!KeysLoaded || State.PublicKey is null || this.LocalEndpoint.FindLocalEndpoint(State.PublicKey) is null)
+					continue;
+
 				Output.WriteStartElement("State");
 				Output.WriteAttributeString("legalId", State.LegalId);
 				Output.WriteAttributeString("publicKey", Convert.ToBase64String(State.PublicKey));
@@ -2283,6 +2323,9 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved)), "-Timestamp"))
 			{
+				if (State.PublicKey is null)
+					continue;
+
 				if (!(PublicKey is null) && Convert.ToBase64String(State.PublicKey) != PublicKeyBase64)
 					continue;
 
@@ -2305,6 +2348,9 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("State", IdentityState.Approved)), "-Timestamp"))
 			{
 				HaveStates = true;
+
+				if (State.PublicKey is null)
+					continue;
 
 				IE2eEndpoint Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
 				if (Endpoint is null)

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;
@@ -135,6 +136,8 @@ namespace Waher.Networking.XMPP.Contracts
 		private readonly Dictionary<string, KeyEventArgs> publicKeys = new Dictionary<string, KeyEventArgs>();
 		private readonly Dictionary<string, KeyEventArgs> matchingKeys = new Dictionary<string, KeyEventArgs>();
 		private readonly Cache<string, KeyValuePair<byte[], bool>> contentPerPid = new Cache<string, KeyValuePair<byte[], bool>>(int.MaxValue, TimeSpan.FromDays(1), TimeSpan.FromDays(1));
+		private readonly SemaphoreSlim keyMutationLock = new SemaphoreSlim(1, 1);
+		private readonly AsyncLocal<int> keyMutationDepth = new AsyncLocal<int>();
 		private EndpointSecurity localKeys;
 		private EndpointSecurity localE2eEndpoint;
 		private DateTime keysTimestamp = DateTime.MinValue;
@@ -166,6 +169,39 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				if (this.MustDispose)
 					this.Endpoint?.Dispose();
+			}
+		}
+
+		private sealed class LoadedKeySet : IDisposable
+		{
+			private IE2eEndpoint[] keys;
+			private bool transferred;
+
+			public LoadedKeySet(IE2eEndpoint[] Keys, DateTime Timestamp)
+			{
+				this.keys = Keys;
+				this.Timestamp = Timestamp;
+			}
+
+			public IE2eEndpoint[] Keys => this.keys;
+
+			public DateTime Timestamp { get; }
+
+			public IE2eEndpoint[] TransferKeys()
+			{
+				this.transferred = true;
+				return this.keys;
+			}
+
+			public void Dispose()
+			{
+				if (!this.transferred && !(this.keys is null))
+				{
+					foreach (IE2eEndpoint Key in this.keys)
+						Key.Dispose();
+				}
+
+				this.keys = Array.Empty<IE2eEndpoint>();
 			}
 		}
 
@@ -331,9 +367,13 @@ namespace Waher.Networking.XMPP.Contracts
 			if (this.disposeLocalKeys)
 				this.localKeys?.Dispose();
 
+			if (ReferenceEquals(this.localE2eEndpoint, this.localKeys))
+				this.localE2eEndpoint = null;
+
 			this.localKeys = null;
 			this.disposeLocalKeys = false;
 			this.keysTimestamp = DateTime.MinValue;
+			this.keyMutationLock.Dispose();
 
 			this.rnd?.Dispose();
 			this.rnd = null;
@@ -406,36 +446,101 @@ namespace Waher.Networking.XMPP.Contracts
 			return this.LoadKeys(CreateIfNone, null);
 		}
 
+		private async Task<T> RunKeyMutationAsync<T>(Func<Task<T>> Callback)
+		{
+			if (this.keyMutationDepth.Value > 0)
+			{
+				this.keyMutationDepth.Value++;
+				try
+				{
+					return await Callback();
+				}
+				finally
+				{
+					this.keyMutationDepth.Value--;
+				}
+			}
+
+			await this.keyMutationLock.WaitAsync();
+			this.keyMutationDepth.Value = 1;
+
+			try
+			{
+				return await Callback();
+			}
+			finally
+			{
+				this.keyMutationDepth.Value = 0;
+				this.keyMutationLock.Release();
+			}
+		}
+
+		private Task RunKeyMutationAsync(Func<Task> Callback)
+		{
+			return this.RunKeyMutationAsync(async () =>
+			{
+				await Callback();
+				return true;
+			});
+		}
+
 		/// <summary>
 		/// Loads keys from the underlying persistence layer.
 		/// </summary>
 		/// <param name="CreateIfNone">Allows new keys to be created, if no keys were found in the persistence layer.</param>
 		/// <param name="Thread">Optional thread to use during profiling.</param>
 		/// <returns>If keys were loaded or generated (i.e. can be used) or not.</returns>
-		public async Task<bool> LoadKeys(bool CreateIfNone, ProfilerThread Thread)
+		public Task<bool> LoadKeys(bool CreateIfNone, ProfilerThread Thread)
+		{
+			return this.RunKeyMutationAsync(() => this.LoadKeysInternalAsync(CreateIfNone, Thread));
+		}
+
+		private async Task<bool> LoadKeysInternalAsync(bool CreateIfNone, ProfilerThread Thread)
+		{
+			return await this.LoadKeysInternalAsync(CreateIfNone, Thread, this.localKeysForE2e, this.localE2eEndpoint);
+		}
+
+		private async Task<bool> LoadKeysInternalAsync(bool CreateIfNone, ProfilerThread Thread, bool UseLocalKeysForE2e,
+			EndpointSecurity DesiredLocalE2eEndpoint)
 		{
 			Thread = Thread?.CreateSubThread("Load Keys", ProfilerThreadType.Sequential);
 			Thread?.Start();
 			try
 			{
-				Thread?.NewState("Search");
+				using LoadedKeySet LoadedKeys = await this.LoadPersistedKeysAsync(CreateIfNone, Thread);
+				if (LoadedKeys is null)
+					return false;
 
-				List<IE2eEndpoint> Keys = new List<IE2eEndpoint>();
-				Dictionary<string, object> Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
+				await this.ActivateLoadedKeysAsync(LoadedKeys, Thread, UseLocalKeysForE2e, DesiredLocalE2eEndpoint);
+				return true;
+			}
+			finally
+			{
+				Thread?.Stop();
+			}
+		}
 
-				Thread?.NewState("Endpoints");
+		private async Task<LoadedKeySet> LoadPersistedKeysAsync(bool CreateIfNone, ProfilerThread Thread)
+		{
+			Thread?.NewState("Search");
 
-				IE2eEndpoint[] AvailableEndpoints = EndpointSecurity.CreateEndpoints(256, 192,
-					int.MaxValue, new Type[]
-					{
-						typeof(EllipticCurveEndpoint),
-						typeof(ModuleLatticeEndpoint)
-					}, Thread);
+			List<IE2eEndpoint> Keys = new List<IE2eEndpoint>();
+			Dictionary<string, object> Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
 
-				DateTime? Timestamp = null;
-				bool DisposeEndpoints = true;
-				byte[] Key;
+			Thread?.NewState("Endpoints");
 
+			IE2eEndpoint[] AvailableEndpoints = EndpointSecurity.CreateEndpoints(256, 192,
+				int.MaxValue, new Type[]
+				{
+					typeof(EllipticCurveEndpoint),
+					typeof(ModuleLatticeEndpoint)
+				}, Thread);
+
+			DateTime? Timestamp = null;
+			byte[] Key;
+
+			try
+			{
 				Thread?.NewState("Select");
 
 				foreach (KeyValuePair<string, object> Setting in Settings)
@@ -479,13 +584,12 @@ namespace Waher.Networking.XMPP.Contracts
 				if (Keys.Count == 0 || (Keys.Count != AvailableEndpoints.Length && CreateIfNone))
 				{
 					if (!CreateIfNone)
-						return false;
+						return null;
 
 					Thread?.NewState("Create");
 
-					DisposeEndpoints = false;
-
-					int i, c = Keys.Count;
+					int i;
+					int c = Keys.Count;
 
 					foreach (IE2eEndpoint Endpoint in AvailableEndpoints)
 					{
@@ -522,64 +626,105 @@ namespace Waher.Networking.XMPP.Contracts
 					await RuntimeSettings.SetAsync(this.keySettingsPrefix + "Timestamp", Timestamp.Value);
 				}
 
-				Thread?.NewState("Sec");
-
-				if (this.disposeLocalKeys)
-					this.localKeys?.Dispose();
-
-				this.disposeLocalKeys = false;
-				this.localKeys = null;
-
-				using (Semaphore Lock = await Semaphores.BeginWrite("XMPP.E2E"))
-				{
-					if (this.localKeysForE2e)
-					{
-						if (this.client.TryGetTag("E2E", out object Obj) &&
-							Obj is EndpointSecurity EndpointSecurity)
-						{
-							if (MatchesLoadedKeys(EndpointSecurity, Keys))
-								this.localKeys = EndpointSecurity;
-							else
-							{
-								this.localKeys = new EndpointSecurity(this.client, 128, Keys.ToArray());
-								this.client.SetTag("E2E", this.localKeys);
-								this.disposeLocalKeys = true;
-								EndpointSecurity.Dispose();
-							}
-						}
-						else
-						{
-							this.localKeys = new EndpointSecurity(this.client, 128, Keys.ToArray());
-							this.client.SetTag("E2E", this.localKeys);
-							this.disposeLocalKeys = true;
-						}
-					}
-					else
-					{
-						this.localKeys = new EndpointSecurity(null, 128, Keys.ToArray());
-						this.disposeLocalKeys = true;
-					}
-				}
-
-				this.keysTimestamp = Timestamp.Value;
-
-				if (this.localKeysForE2e)
-					this.localE2eEndpoint = this.localKeys;
-
-				if (DisposeEndpoints)
-				{
-					Thread?.NewState("Dispose");
-
-					foreach (IE2eEndpoint Curve in AvailableEndpoints)
-						Curve.Dispose();
-				}
+				return new LoadedKeySet(Keys.ToArray(), Timestamp.Value);
 			}
 			finally
 			{
-				Thread?.Stop();
+				Thread?.NewState("Dispose");
+
+				HashSet<IE2eEndpoint> LoadedEndpoints = new HashSet<IE2eEndpoint>(Keys);
+
+				foreach (IE2eEndpoint Curve in AvailableEndpoints)
+				{
+					if (!LoadedEndpoints.Contains(Curve))
+						Curve.Dispose();
+				}
+			}
+		}
+
+		private async Task ActivateLoadedKeysAsync(LoadedKeySet LoadedKeys, ProfilerThread Thread, bool UseLocalKeysForE2e,
+			EndpointSecurity DesiredLocalE2eEndpoint)
+		{
+			Thread?.NewState("Sec");
+
+			EndpointSecurity PreviousLocalKeys = this.localKeys;
+			bool DisposePreviousLocalKeys = this.disposeLocalKeys;
+			EndpointSecurity PreviousLocalE2eEndpoint = this.localE2eEndpoint;
+			bool PreviouslySharedLocalKeys = ReferenceEquals(PreviousLocalKeys, PreviousLocalE2eEndpoint);
+			bool PreviousLocalKeysDisposed = false;
+
+			EndpointSecurity NewLocalKeys;
+			bool DisposeNewLocalKeys;
+			EndpointSecurity NewLocalE2eEndpoint = DesiredLocalE2eEndpoint;
+
+			using (Waher.Runtime.Threading.Semaphore Lock = await Semaphores.BeginWrite("XMPP.E2E"))
+			{
+				if (UseLocalKeysForE2e)
+				{
+					if (PreviouslySharedLocalKeys && MatchesLoadedKeys(PreviousLocalE2eEndpoint, LoadedKeys.Keys))
+					{
+						NewLocalKeys = PreviousLocalE2eEndpoint;
+						DisposeNewLocalKeys = DisposePreviousLocalKeys;
+					}
+					else
+					{
+						if (PreviouslySharedLocalKeys)
+						{
+							if (this.client.TryGetTag("E2E", out object Obj) &&
+								ReferenceEquals(Obj, PreviousLocalE2eEndpoint))
+							{
+								this.client.RemoveTag("E2E");
+							}
+
+							if (DisposePreviousLocalKeys)
+							{
+								PreviousLocalKeys.Dispose();
+								PreviousLocalKeysDisposed = true;
+							}
+						}
+
+						NewLocalKeys = new EndpointSecurity(this.client, 128, LoadedKeys.TransferKeys());
+						DisposeNewLocalKeys = true;
+					}
+
+					NewLocalE2eEndpoint = NewLocalKeys;
+					this.client.SetTag("E2E", NewLocalE2eEndpoint);
+				}
+				else
+				{
+					NewLocalKeys = new EndpointSecurity(null, 128, LoadedKeys.TransferKeys());
+					DisposeNewLocalKeys = true;
+
+					if (PreviouslySharedLocalKeys &&
+						this.client.TryGetTag("E2E", out object Obj) &&
+						ReferenceEquals(Obj, PreviousLocalE2eEndpoint))
+					{
+						this.client.RemoveTag("E2E");
+					}
+
+					if (PreviouslySharedLocalKeys)
+						NewLocalE2eEndpoint = null;
+				}
+
+				this.localKeys = NewLocalKeys;
+				this.disposeLocalKeys = DisposeNewLocalKeys;
+				this.localE2eEndpoint = NewLocalE2eEndpoint;
+				this.localKeysForE2e = UseLocalKeysForE2e;
+				this.keysTimestamp = LoadedKeys.Timestamp;
 			}
 
-			return true;
+			if (DisposePreviousLocalKeys && !PreviousLocalKeysDisposed && !ReferenceEquals(PreviousLocalKeys, this.localKeys))
+				PreviousLocalKeys?.Dispose();
+
+			this.ClearMatchingKeyCache();
+		}
+
+		private void ClearMatchingKeyCache()
+		{
+			lock (this.matchingKeys)
+			{
+				this.matchingKeys.Clear();
+			}
 		}
 
 		private byte[] GetKey(EllipticCurveEndpoint EcEndpoint)
@@ -598,22 +743,20 @@ namespace Waher.Networking.XMPP.Contracts
 		/// <summary>
 		/// Generates new keys for the contracts clients.
 		/// </summary>
-		public async Task GenerateNewKeys()
+		public Task GenerateNewKeys()
 		{
-			List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(false);
-
-			foreach (LegalIdentityState State in ActiveStates)
+			return this.RunKeyMutationAsync(async () =>
 			{
-				await this.TryGetLegalIdentityEndpointAsync(State, true);
-			}
+				List<LegalIdentityState> ActiveStates = await this.GetActiveLegalIdentityStatesAsync(false);
 
-			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
-			await this.LoadKeys(true);
+				foreach (LegalIdentityState State in ActiveStates)
+				{
+					await this.TryGetLegalIdentityEndpointAsync(State, true);
+				}
 
-			lock (this.matchingKeys)
-			{
-				this.matchingKeys.Clear();
-			}
+				await RuntimeSettings.DeleteWhereKeyLikeAsync(this.keySettingsPrefix + "*", "*");
+				await this.LoadKeysInternalAsync(true, null);
+			});
 		}
 
 		private async Task<List<LegalIdentityState>> GetActiveLegalIdentityStatesAsync(bool RefreshStates)
@@ -1140,14 +1283,27 @@ namespace Waher.Networking.XMPP.Contracts
 		/// </summary>
 		/// <param name="UseLocalKeys">If local keys should be used in End-to-End encryption.</param>
 		/// <param name="CreateKeysIfNone">If local keys should be created, if none available.</param>
-		public async Task EnableE2eEncryption(bool UseLocalKeys, bool CreateKeysIfNone)
+		public Task EnableE2eEncryption(bool UseLocalKeys, bool CreateKeysIfNone)
 		{
-			bool Reload = !(this.localKeys is null);
+			return this.RunKeyMutationAsync(async () =>
+			{
+				bool Reload = !(this.localKeys is null);
 
-			this.localKeysForE2e = UseLocalKeys;
+				if (Reload)
+				{
+					EndpointSecurity DesiredLocalE2eEndpoint = UseLocalKeys ? this.localE2eEndpoint :
+						ReferenceEquals(this.localE2eEndpoint, this.localKeys) ? null : this.localE2eEndpoint;
 
-			if (Reload)
-				await this.LoadKeys(CreateKeysIfNone);
+					await this.LoadKeysInternalAsync(CreateKeysIfNone, null, UseLocalKeys, DesiredLocalE2eEndpoint);
+				}
+				else
+				{
+					this.localKeysForE2e = UseLocalKeys;
+
+					if (!UseLocalKeys && ReferenceEquals(this.localE2eEndpoint, this.localKeys))
+						this.localE2eEndpoint = null;
+				}
+			});
 		}
 
 		/// <summary>
@@ -1164,15 +1320,20 @@ namespace Waher.Networking.XMPP.Contracts
 		/// </summary>
 		/// <param name="E2eEndpoint">Endpoint managing the keys on the network.</param>
 		/// <param name="CreateKeysIfNone">If local keys should be created, if none available.</param>
-		public async Task EnableE2eEncryption(EndpointSecurity E2eEndpoint, bool CreateKeysIfNone)
+		public Task EnableE2eEncryption(EndpointSecurity E2eEndpoint, bool CreateKeysIfNone)
 		{
-			bool Reload = !(this.localKeys is null);
+			return this.RunKeyMutationAsync(async () =>
+			{
+				bool Reload = !(this.localKeys is null);
 
-			this.localKeysForE2e = false;
-			this.localE2eEndpoint = E2eEndpoint;
-
-			if (Reload)
-				await this.LoadKeys(CreateKeysIfNone);
+				if (Reload)
+					await this.LoadKeysInternalAsync(CreateKeysIfNone, null, false, E2eEndpoint);
+				else
+				{
+					this.localKeysForE2e = false;
+					this.localE2eEndpoint = E2eEndpoint;
+				}
+			});
 		}
 
 		/// <summary>

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -1004,6 +1004,162 @@ namespace Waher.Networking.XMPP.Contracts
 				: new ResolvedLegalIdentityKey(Endpoint2, true);
 		}
 
+		private static bool TryParseContractSharedSecret(string Value, out SymmetricCipherAlgorithms Algorithm,
+			out string CreatorJid, out byte[] SharedSecret)
+		{
+			Algorithm = DefaultCipherAlgorithm;
+			CreatorJid = string.Empty;
+			SharedSecret = null;
+
+			if (string.IsNullOrEmpty(Value))
+				return false;
+
+			string[] Parts = Value.Split('|');
+			if (Parts.Length != 3 || !Enum.TryParse(Parts[0], out Algorithm))
+				return false;
+
+			CreatorJid = Parts[1];
+
+			try
+			{
+				SharedSecret = Convert.FromBase64String(Parts[2]);
+			}
+			catch (Exception)
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		private static Tuple<SymmetricCipherAlgorithms, string, byte[]> CreateContractSharedSecretTuple(
+			SymmetricCipherAlgorithms Algorithm, string CreatorJid, byte[] SharedSecret)
+		{
+			if (SharedSecret is null)
+				return null;
+
+			return new Tuple<SymmetricCipherAlgorithms, string, byte[]>(Algorithm, CreatorJid ?? string.Empty,
+				(byte[])SharedSecret.Clone());
+		}
+
+		private static string EncodeContractSharedSecret(SymmetricCipherAlgorithms Algorithm, string CreatorJid, byte[] SharedSecret)
+		{
+			if (SharedSecret is null)
+				return null;
+
+			return Algorithm.ToString() + "|" + (CreatorJid ?? string.Empty) + "|" + Convert.ToBase64String(SharedSecret);
+		}
+
+		private async Task<ContractSharedSecretState> GetContractStateAsync(string ContractId)
+		{
+			return await Database.FindFirstDeleteRest<ContractSharedSecretState>(new FilterAnd(
+				new FilterFieldEqualTo("BareJid", this.client.BareJID),
+				new FilterFieldEqualTo("ContractId", ContractId)));
+		}
+
+		private async Task<bool> UpsertContractStateAsync(string ContractId, string CreatorJid, byte[] SharedSecret,
+			SymmetricCipherAlgorithms KeyAlgorithm)
+		{
+			if (string.IsNullOrEmpty(ContractId) || SharedSecret is null)
+				return false;
+
+			ContractSharedSecretState State = await this.GetContractStateAsync(ContractId);
+			byte[] SecretCopy = (byte[])SharedSecret.Clone();
+
+			if (State is null)
+			{
+				State = new ContractSharedSecretState(ContractId)
+				{
+					BareJid = this.client.BareJID,
+					CreatorJid = CreatorJid ?? string.Empty,
+					KeyAlgorithm = KeyAlgorithm,
+					SharedSecret = SecretCopy
+				};
+
+				await Database.Insert(State);
+			}
+			else
+			{
+				State.CreatorJid = CreatorJid ?? string.Empty;
+				State.KeyAlgorithm = KeyAlgorithm;
+				State.SharedSecret = SecretCopy;
+
+				await Database.Update(State);
+			}
+
+			return true;
+		}
+
+		private Tuple<SymmetricCipherAlgorithms, string, byte[]> TryLoadContractSharedSecret(ContractSharedSecretState State)
+		{
+			if (State is null || string.IsNullOrEmpty(State.ContractId) || !State.HasSharedSecret)
+				return null;
+
+			return CreateContractSharedSecretTuple(State.KeyAlgorithm, State.CreatorJid, State.SharedSecret);
+		}
+
+		private async Task<Tuple<SymmetricCipherAlgorithms, string, byte[]>> TryLoadLegacyContractSharedSecretAsync(
+			string ContractId, bool MigrateToState)
+		{
+			string Name = this.contractKeySettingsPrefix + ContractId;
+			string Value = await RuntimeSettings.GetAsync(Name, string.Empty);
+
+			if (!TryParseContractSharedSecret(Value, out SymmetricCipherAlgorithms Algorithm, out string CreatorJid,
+				out byte[] SharedSecret))
+			{
+				return null;
+			}
+
+			if (MigrateToState)
+				await this.UpsertContractStateAsync(ContractId, CreatorJid, SharedSecret, Algorithm);
+
+			return CreateContractSharedSecretTuple(Algorithm, CreatorJid, SharedSecret);
+		}
+
+		private async Task<List<ContractSharedSecretState>> GetExportableContractStatesAsync()
+		{
+			Dictionary<string, ContractSharedSecretState> ContractStates = new Dictionary<string, ContractSharedSecretState>(StringComparer.Ordinal);
+			List<ContractSharedSecretState> Result = new List<ContractSharedSecretState>();
+
+			foreach (ContractSharedSecretState State in await Database.Find<ContractSharedSecretState>(new FilterFieldEqualTo("BareJid", this.client.BareJID)))
+			{
+				if (string.IsNullOrEmpty(State.ContractId) || !State.HasSharedSecret)
+					continue;
+
+				ContractStates[State.ContractId] = State;
+			}
+
+			Dictionary<string, object> Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.contractKeySettingsPrefix + "*", "*");
+
+			foreach (KeyValuePair<string, object> Setting in Settings)
+			{
+				if (!(Setting.Value is string Value))
+					continue;
+
+				string ContractId = Setting.Key[this.contractKeySettingsPrefix.Length..];
+
+				if (ContractStates.ContainsKey(ContractId) ||
+					!TryParseContractSharedSecret(Value, out SymmetricCipherAlgorithms Algorithm, out string CreatorJid,
+						out byte[] SharedSecret))
+				{
+					continue;
+				}
+
+				if (await this.UpsertContractStateAsync(ContractId, CreatorJid, SharedSecret, Algorithm))
+				{
+					ContractSharedSecretState State = await this.GetContractStateAsync(ContractId);
+
+					if (!(State is null))
+						ContractStates[ContractId] = State;
+				}
+			}
+
+			foreach (ContractSharedSecretState State in ContractStates.Values)
+				Result.Add(State);
+
+			return Result;
+		}
+
 		/// <summary>
 		/// Exports Keys to XML.
 		/// </summary>
@@ -1077,19 +1233,16 @@ namespace Waher.Networking.XMPP.Contracts
 				Output.WriteEndElement();
 			}
 
-			Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.contractKeySettingsPrefix + "*", "*");
-
-			foreach (KeyValuePair<string, object> Setting in Settings)
+			foreach (ContractSharedSecretState ContractState in await this.GetExportableContractStatesAsync())
 			{
-				string Name = Setting.Key[this.contractKeySettingsPrefix.Length..];
+				if (!ContractState.HasSharedSecret)
+					continue;
 
-				if (Setting.Value is string s)
-				{
-					Output.WriteStartElement("C");
-					Output.WriteAttributeString("n", Name);
-					Output.WriteAttributeString("v", s);
-					Output.WriteEndElement();
-				}
+				Output.WriteStartElement("C");
+				Output.WriteAttributeString("n", ContractState.ContractId);
+				Output.WriteAttributeString("v", EncodeContractSharedSecret(ContractState.KeyAlgorithm,
+					ContractState.CreatorJid, ContractState.SharedSecret));
+				Output.WriteEndElement();
 			}
 
 			Output.WriteEndElement();
@@ -1154,11 +1307,46 @@ namespace Waher.Networking.XMPP.Contracts
 						break;
 
 					case "C":
+					{
 						Name = XML.Attribute(E, "n");
 						StringValue = XML.Attribute(E, "v");
 
-						await RuntimeSettings.SetAsync(this.contractKeySettingsPrefix + Name, StringValue);
+						if (!TryParseContractSharedSecret(StringValue, out SymmetricCipherAlgorithms ContractAlgorithm,
+							out string CreatorJid, out byte[] SharedSecret))
+						{
+							return false;
+						}
+
+						if (!await this.UpsertContractStateAsync(Name, CreatorJid, SharedSecret, ContractAlgorithm))
+							return false;
 						break;
+					}
+
+					case "ContractState":
+					{
+						string ContractId = XML.Attribute(E, "contractId");
+						string CreatorJid = XML.Attribute(E, "creatorJid");
+						string KeyAlgorithm = XML.Attribute(E, "keyAlgorithm");
+						string SharedSecretStr = XML.Attribute(E, "sharedSecret");
+						SymmetricCipherAlgorithms ContractAlgorithm;
+						byte[] SharedSecret;
+
+						if (!Enum.TryParse(KeyAlgorithm, out ContractAlgorithm))
+							return false;
+
+						try
+						{
+							SharedSecret = Convert.FromBase64String(SharedSecretStr);
+						}
+						catch (Exception)
+						{
+							return false;
+						}
+
+						if (!await this.UpsertContractStateAsync(ContractId, CreatorJid, SharedSecret, ContractAlgorithm))
+							return false;
+						break;
+					}
 
 					case "State":
 						string LegalId = XML.Attribute(E, "legalId");
@@ -1432,6 +1620,7 @@ namespace Waher.Networking.XMPP.Contracts
 
 			this.approvedSources = ApprovedSources;
 			this.SetLegalIdentityStateAllowedSources(ApprovedSources);
+			this.SetContractStateAllowedSources(ApprovedSources);
 		}
 
 		private void AssertAllowed()
@@ -1448,6 +1637,21 @@ namespace Waher.Networking.XMPP.Contracts
 			try
 			{
 				LegalIdentityState.SetAllowedSources(ApprovedSources);
+			}
+			catch (NotSupportedException)
+			{
+				// Sensitive state access has already been configured globally.
+			}
+		}
+
+		private void SetContractStateAllowedSources(ICallStackCheck[] ApprovedSources)
+		{
+			if (ApprovedSources is null)
+				return;
+
+			try
+			{
+				ContractSharedSecretState.SetAllowedSources(ApprovedSources);
 			}
 			catch (NotSupportedException)
 			{
@@ -6368,50 +6572,32 @@ namespace Waher.Networking.XMPP.Contracts
 		internal async Task<bool> SaveContractSharedSecret(string ContractId, string CreatorJid, byte[] Key,
 			SymmetricCipherAlgorithms KeyAlgorithm, bool OnlyIfNew)
 		{
-			string Name = this.contractKeySettingsPrefix + ContractId;
-
 			if (OnlyIfNew)
 			{
-				string s = await RuntimeSettings.GetAsync(Name, string.Empty);
-				if (!string.IsNullOrEmpty(s))
+				ContractSharedSecretState State = await this.GetContractStateAsync(ContractId);
+
+				if (!(State is null) && State.HasSharedSecret)
+					return false;
+
+				if (!(await this.TryLoadLegacyContractSharedSecretAsync(ContractId, true) is null))
 					return false;
 			}
 
-			string Value = KeyAlgorithm.ToString() + "|" + CreatorJid + "|" + Convert.ToBase64String(Key);
-
-			await RuntimeSettings.SetAsync(Name, Value);
-
-			return true;
+			return await this.UpsertContractStateAsync(ContractId, CreatorJid, Key, KeyAlgorithm);
 		}
 
 		internal async Task<Tuple<SymmetricCipherAlgorithms, string, byte[]>> TryLoadContractSharedSecret(string ContractId)
 		{
-			string Name = this.contractKeySettingsPrefix + ContractId;
-			string s = await RuntimeSettings.GetAsync(Name, string.Empty);
+			ContractSharedSecretState State = await this.GetContractStateAsync(ContractId);
+			Tuple<SymmetricCipherAlgorithms, string, byte[]> Result = this.TryLoadContractSharedSecret(State);
 
-			if (string.IsNullOrEmpty(s))
+			if (!(Result is null))
+				return Result;
+
+			if (!(State is null))
 				return null;
 
-			string[] Parts = s.Split('|');
-			if (Parts.Length != 3)
-				return null;
-
-			if (!Enum.TryParse(Parts[0], out SymmetricCipherAlgorithms Algorithm))
-				return null;
-
-			string CreatorJid = Parts[1];
-			byte[] Key;
-
-			try
-			{
-				Key = Convert.FromBase64String(Parts[2]);
-			}
-			catch (Exception)
-			{
-				return null;
-			}
-
-			return new Tuple<SymmetricCipherAlgorithms, string, byte[]>(Algorithm, CreatorJid, Key);
+			return await this.TryLoadLegacyContractSharedSecretAsync(ContractId, true);
 		}
 
 		/// <summary>

--- a/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/ContractsClient.cs
@@ -150,6 +150,25 @@ namespace Waher.Networking.XMPP.Contracts
 		private RandomNumberGenerator rnd = RandomNumberGenerator.Create();
 		private Aes aes;
 
+		private sealed class ResolvedLegalIdentityKey : IDisposable
+		{
+			public ResolvedLegalIdentityKey(IE2eEndpoint Endpoint, bool MustDispose)
+			{
+				this.Endpoint = Endpoint;
+				this.MustDispose = MustDispose;
+			}
+
+			public IE2eEndpoint Endpoint { get; }
+
+			public bool MustDispose { get; }
+
+			public void Dispose()
+			{
+				if (this.MustDispose)
+					this.Endpoint?.Dispose();
+			}
+		}
+
 		#region Construction
 
 		/// <summary>
@@ -767,7 +786,7 @@ namespace Waher.Networking.XMPP.Contracts
 			return Updated;
 		}
 
-		private async Task<Tuple<IE2eEndpoint, bool>> TryGetLegalIdentityEndpointAsync(LegalIdentityState State, bool MigrateLegacyState)
+		private async Task<ResolvedLegalIdentityKey> TryGetLegalIdentityEndpointAsync(LegalIdentityState State, bool MigrateLegacyState)
 		{
 			IE2eEndpoint Endpoint = this.TryCreateLegalIdentityEndpoint(State);
 
@@ -779,7 +798,7 @@ namespace Waher.Networking.XMPP.Contracts
 					if (!string.IsNullOrEmpty(State.ObjectId))
 						await Database.Update(State);
 
-					return new Tuple<IE2eEndpoint, bool>(Endpoint, true);
+					return new ResolvedLegalIdentityKey(Endpoint, true);
 				}
 				else if (!AreEqual(State.PublicKey, Endpoint.PublicKey))
 				{
@@ -787,23 +806,23 @@ namespace Waher.Networking.XMPP.Contracts
 					Endpoint = null;
 				}
 				else
-					return new Tuple<IE2eEndpoint, bool>(Endpoint, true);
+					return new ResolvedLegalIdentityKey(Endpoint, true);
 			}
 
 			if (!MigrateLegacyState || State?.PublicKey is null || !await this.LoadKeys(false))
-				return new Tuple<IE2eEndpoint, bool>(null, false);
+				return new ResolvedLegalIdentityKey(null, false);
 
 			Endpoint = this.LocalEndpoint.FindLocalEndpoint(State.PublicKey);
 			if (Endpoint is null || !await this.SetLegalIdentityKeySnapshotAsync(State, Endpoint))
-				return new Tuple<IE2eEndpoint, bool>(Endpoint, false);
+				return new ResolvedLegalIdentityKey(Endpoint, false);
 
 			if (!string.IsNullOrEmpty(State.ObjectId))
 				await Database.Update(State);
 
 			IE2eEndpoint Endpoint2 = this.TryCreateLegalIdentityEndpoint(State);
 			return Endpoint2 is null ?
-				new Tuple<IE2eEndpoint, bool>(Endpoint, false)
-				: new Tuple<IE2eEndpoint, bool>(Endpoint2, true);
+				new ResolvedLegalIdentityKey(Endpoint, false)
+				: new ResolvedLegalIdentityKey(Endpoint2, true);
 		}
 
 		/// <summary>
@@ -859,32 +878,24 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved))))
 			{
-				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
-				IE2eEndpoint Endpoint = P.Item1;
+				using ResolvedLegalIdentityKey Key = await this.TryGetLegalIdentityEndpointAsync(State, true);
+				IE2eEndpoint Endpoint = Key.Endpoint;
 
 				if (Endpoint is null || State.PublicKey is null || !State.HasPrivateKey || string.IsNullOrEmpty(State.KeyName))
 					continue;
 
-				try
-				{
-					Output.WriteStartElement("State");
-					Output.WriteAttributeString("legalId", State.LegalId);
-					Output.WriteAttributeString("publicKey", Convert.ToBase64String(State.PublicKey));
-					Output.WriteAttributeString("timestamp", XML.Encode(State.Timestamp));
-					Output.WriteAttributeString("keyName", State.KeyName);
+				Output.WriteStartElement("State");
+				Output.WriteAttributeString("legalId", State.LegalId);
+				Output.WriteAttributeString("publicKey", Convert.ToBase64String(State.PublicKey));
+				Output.WriteAttributeString("timestamp", XML.Encode(State.Timestamp));
+				Output.WriteAttributeString("keyName", State.KeyName);
 
-					if (!string.IsNullOrEmpty(State.KeyNamespace))
-						Output.WriteAttributeString("keyNamespace", State.KeyNamespace);
+				if (!string.IsNullOrEmpty(State.KeyNamespace))
+					Output.WriteAttributeString("keyNamespace", State.KeyNamespace);
 
-					Output.WriteAttributeString("hasPrivateKey", CommonTypes.Encode(State.HasPrivateKey));
-					Output.WriteAttributeString("privateKey", Convert.ToBase64String(State.PrivateKey));
-					Output.WriteEndElement();
-				}
-				finally
-				{
-					if (P.Item2)
-						Endpoint.Dispose();
-				}
+				Output.WriteAttributeString("hasPrivateKey", CommonTypes.Encode(State.HasPrivateKey));
+				Output.WriteAttributeString("privateKey", Convert.ToBase64String(State.PrivateKey));
+				Output.WriteEndElement();
 			}
 
 			Settings = await RuntimeSettings.GetWhereKeyLikeAsync(this.contractKeySettingsPrefix + "*", "*");
@@ -2478,17 +2489,9 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("LegalId", IdentityId)));
 
-			Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
+			using ResolvedLegalIdentityKey Key = await this.TryGetLegalIdentityEndpointAsync(State, true);
 
-			try
-			{
-				return !(P.Item1 is null);
-			}
-			finally
-			{
-				if (P.Item2)
-					P.Item1?.Dispose();
-			}
+			return !(Key.Endpoint is null);
 		}
 
 		/// <summary>
@@ -2513,29 +2516,21 @@ namespace Waher.Networking.XMPP.Contracts
 				new FilterFieldEqualTo("BareJid", this.client.BareJID),
 				new FilterFieldEqualTo("State", IdentityState.Approved)), "-Timestamp"))
 			{
-				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
+				using ResolvedLegalIdentityKey Key = await this.TryGetLegalIdentityEndpointAsync(State, true);
 
-				try
-				{
-					if (P.Item1 is null || State.PublicKey is null)
-						continue;
+				if (Key.Endpoint is null || State.PublicKey is null)
+					continue;
 
-					if (!(PublicKey is null) && Convert.ToBase64String(State.PublicKey) != PublicKeyBase64)
-						continue;
+				if (!(PublicKey is null) && Convert.ToBase64String(State.PublicKey) != PublicKeyBase64)
+					continue;
 
-					return State.LegalId;
-				}
-				finally
-				{
-					if (P.Item2)
-						P.Item1?.Dispose();
-				}
+				return State.LegalId;
 			}
 
 			return null;
 		}
 
-		private async Task<Tuple<IE2eEndpoint, bool>> GetLatestApprovedKey(bool ExceptionIfNone)
+		private async Task<ResolvedLegalIdentityKey> GetLatestApprovedKey(bool ExceptionIfNone)
 		{
 			bool HaveStates = false;
 
@@ -2545,9 +2540,11 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				HaveStates = true;
 
-				Tuple<IE2eEndpoint, bool> P = await this.TryGetLegalIdentityEndpointAsync(State, true);
-				if (!(P.Item1 is null))
-					return P;
+				ResolvedLegalIdentityKey Key = await this.TryGetLegalIdentityEndpointAsync(State, true);
+				if (!(Key.Endpoint is null))
+					return Key;
+
+				Key.Dispose();
 			}
 
 			if (ExceptionIfNone)
@@ -2561,7 +2558,7 @@ namespace Waher.Networking.XMPP.Contracts
 					throw new Exception("No approved legal identity available on this device (" + this.client.BareJID + ").");
 			}
 
-			return new Tuple<IE2eEndpoint, bool>(null, false);
+			return new ResolvedLegalIdentityKey(null, false);
 		}
 
 		private async Task<LegalIdentityState> FindPreviewStateAsync(byte[] PublicKey, string LegalId)
@@ -3021,16 +3018,18 @@ namespace Waher.Networking.XMPP.Contracts
 			this.AssertAllowed();
 
 			byte[] Signature = null;
-			Tuple<IE2eEndpoint, bool> P = SignWith switch
+			ResolvedLegalIdentityKey KeyInfo = SignWith switch
 			{
-				SignWith.CurrentKeys => new Tuple<IE2eEndpoint, bool>(null, false),
+				SignWith.CurrentKeys => new ResolvedLegalIdentityKey(null, false),
 				SignWith.LatestApprovedId => await this.GetLatestApprovedKey(true),
 				_ => await this.GetLatestApprovedKey(false),
 			};
-			IE2eEndpoint Key = P.Item1;
+			IE2eEndpoint Key = KeyInfo.Endpoint;
 
 			if (Key is null)
 			{
+				KeyInfo.Dispose();
+
 				await this.GetMatchingLocalKey(Address, async (Sender, e) =>
 				{
 					if (e.Ok)
@@ -3042,16 +3041,11 @@ namespace Waher.Networking.XMPP.Contracts
 			}
 			else
 			{
-				try
+				using (KeyInfo)
 				{
 					Signature = Key.Sign(Data);
 
 					await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
-				}
-				finally
-				{
-					if (P.Item2)
-						Key.Dispose();
 				}
 			}
 		}
@@ -3116,14 +3110,16 @@ namespace Waher.Networking.XMPP.Contracts
 		{
 			this.AssertAllowed();
 
-			Tuple<IE2eEndpoint, bool> P = SignWith == SignWith.CurrentKeys ?
-				new Tuple<IE2eEndpoint, bool>(null, false)
+			ResolvedLegalIdentityKey KeyInfo = SignWith == SignWith.CurrentKeys ?
+				new ResolvedLegalIdentityKey(null, false)
 				: await this.GetLatestApprovedKey(true);
-			IE2eEndpoint Key = P.Item1;
+			IE2eEndpoint Key = KeyInfo.Endpoint;
 			byte[] Signature = null;
 
 			if (Key is null)
 			{
+				KeyInfo.Dispose();
+
 				await this.GetMatchingLocalKey(Address, async (Sender, e) =>
 				{
 					if (e.Ok)
@@ -3135,16 +3131,11 @@ namespace Waher.Networking.XMPP.Contracts
 			}
 			else
 			{
-				try
+				using (KeyInfo)
 				{
 					Signature = Key.Sign(Data);
 
 					await Callback.Raise(this, new SignatureEventArgs(Key, Signature, State));
-				}
-				finally
-				{
-					if (P.Item2)
-						Key.Dispose();
 				}
 			}
 		}

--- a/Networking/Waher.Networking.XMPP.Contracts/LegalIdentityState.cs
+++ b/Networking/Waher.Networking.XMPP.Contracts/LegalIdentityState.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Text;
 using Waher.Persistence;
 using Waher.Persistence.Attributes;
 using Waher.Runtime.Inventory;
+using Waher.Security.CallStack;
 
 namespace Waher.Networking.XMPP.Contracts
 {
@@ -14,12 +15,17 @@ namespace Waher.Networking.XMPP.Contracts
 	[Index("BareJid", "LegalId")]
 	[Index("BareJid", "State", "Timestamp")]
 	[Singleton]
-	public class LegalIdentityState
+	public class LegalIdentityState : IEncryptedProperties
 	{
+		private static ICallStackCheck[] approvedSources = null;
+
 		private string objectId = null;
 		private CaseInsensitiveString bareJid = CaseInsensitiveString.Empty;
 		private CaseInsensitiveString legalId = CaseInsensitiveString.Empty;
 		private byte[] publicKey = null;
+		private string keyName = null;
+		private string keyNamespace = null;
+		private byte[] privateKey = null;
 		private IdentityState state = IdentityState.Created;
 		private DateTime timestamp = DateTime.MinValue;
 
@@ -78,6 +84,53 @@ namespace Waher.Networking.XMPP.Contracts
 		}
 
 		/// <summary>
+		/// Name of key algorithm used when the identity was created.
+		/// </summary>
+		[DefaultValueNull]
+		public string KeyName
+		{
+			get => this.keyName;
+			set => this.keyName = value;
+		}
+
+		/// <summary>
+		/// Namespace of key algorithm used when the identity was created.
+		/// </summary>
+		[DefaultValueNull]
+		public string KeyNamespace
+		{
+			get => this.keyNamespace;
+			set => this.keyNamespace = value;
+		}
+
+		/// <summary>
+		/// If a private key snapshot is available for the legal identity.
+		/// </summary>
+		public bool HasPrivateKey => !(this.privateKey is null);
+
+		/// <summary>
+		/// Private key snapshot stored with the legal identity.
+		/// </summary>
+		[DefaultValueNull]
+		[Encrypted(32)]
+		public byte[] PrivateKey
+		{
+			get
+			{
+				AssertAllowed();
+				return this.privateKey;
+			}
+
+			set
+			{
+				if (!(this.privateKey is null))
+					AssertAllowed();
+
+				this.privateKey = value;
+			}
+		}
+
+		/// <summary>
 		/// State of the legal identity.
 		/// </summary>
 		public IdentityState State
@@ -93,6 +146,33 @@ namespace Waher.Networking.XMPP.Contracts
 		{
 			get => this.timestamp;
 			set => this.timestamp = value;
+		}
+
+		/// <summary>
+		/// Array of properties that are encrypted.
+		/// </summary>
+		public string[] EncryptedProperties => new string[]
+		{
+			nameof(this.PrivateKey)
+		};
+
+		/// <summary>
+		/// If access to sensitive properties is only accessible from a set of approved sources.
+		/// </summary>
+		/// <param name="ApprovedSources">Approved sources.</param>
+		/// <exception cref="NotSupportedException">If trying to change previously set sources.</exception>
+		public static void SetAllowedSources(ICallStackCheck[] ApprovedSources)
+		{
+			if (!(approvedSources is null))
+				throw new NotSupportedException("Changing approved sources not permitted.");
+
+			approvedSources = ApprovedSources;
+		}
+
+		private static void AssertAllowed()
+		{
+			if (!(approvedSources is null))
+				Assert.CallFromSource(approvedSources);
 		}
 
 		/// <inheritdoc/>
@@ -112,6 +192,23 @@ namespace Waher.Networking.XMPP.Contracts
 			{
 				sb.Append(", ");
 				sb.Append(Convert.ToBase64String(this.publicKey));
+			}
+
+			if (!string.IsNullOrEmpty(this.keyName))
+			{
+				sb.Append(", ");
+				sb.Append(this.keyName);
+			}
+
+			if (!string.IsNullOrEmpty(this.keyNamespace))
+			{
+				sb.Append(", ");
+				sb.Append(this.keyNamespace);
+			}
+
+			if (!(this.privateKey is null))
+			{
+				sb.Append(", PrivateKey");
 			}
 
 			return sb.ToString();

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Waher.Networking.XMPP.Contracts;
 using Waher.Networking.XMPP.P2P;
 using Waher.Networking.XMPP.P2P.E2E;
+using Waher.Networking.XMPP.P2P.SymmetricCiphers;
 using Waher.Persistence;
 using Waher.Persistence.Files;
 using Waher.Persistence.Filters;
@@ -443,6 +444,170 @@ namespace Waher.Networking.XMPP.Test
 			}
 		}
 
+		[TestMethod]
+		public async Task ContractsClient_State_Test_17_SaveContractSharedSecretPersistsContractState()
+		{
+			byte[] SharedSecret = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+			Assert.IsTrue(await InvokeSaveContractSharedSecretAsync(this.contractsClient, "contract-state-id", this.client.BareJID,
+				SharedSecret, SymmetricCipherAlgorithms.Aes256, false));
+
+			ContractSharedSecretState State = await GetContractStateAsync(this.client.BareJID, "contract-state-id");
+			Assert.IsNotNull(State);
+			Assert.AreEqual(this.client.BareJID, State.CreatorJid);
+			Assert.AreEqual(SymmetricCipherAlgorithms.Aes256, State.KeyAlgorithm);
+			CollectionAssert.AreEqual(SharedSecret, State.SharedSecret);
+			Assert.AreEqual(string.Empty, await RuntimeSettings.GetAsync(
+				this.contractsClient.ContractKeySettingsPrefix + "contract-state-id", string.Empty));
+
+			Tuple<SymmetricCipherAlgorithms, string, byte[]> Secret = await InvokeTryLoadContractSharedSecretAsync(this.contractsClient, "contract-state-id");
+			Assert.IsNotNull(Secret);
+			Assert.AreEqual(SymmetricCipherAlgorithms.Aes256, Secret.Item1);
+			Assert.AreEqual(this.client.BareJID, Secret.Item2);
+			CollectionAssert.AreEqual(SharedSecret, Secret.Item3);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_18_LegacyContractSharedSecretBackfillsContractStateOnLoad()
+		{
+			byte[] SharedSecret = new byte[] { 9, 8, 7, 6, 5, 4 };
+			await RuntimeSettings.SetAsync(this.contractsClient.ContractKeySettingsPrefix + "legacy-contract-id",
+				EncodeLegacyContractSharedSecret(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, "creator@example.org", SharedSecret));
+
+			Tuple<SymmetricCipherAlgorithms, string, byte[]> Secret = await InvokeTryLoadContractSharedSecretAsync(this.contractsClient, "legacy-contract-id");
+			Assert.IsNotNull(Secret);
+			Assert.AreEqual(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, Secret.Item1);
+			Assert.AreEqual("creator@example.org", Secret.Item2);
+			CollectionAssert.AreEqual(SharedSecret, Secret.Item3);
+
+			ContractSharedSecretState State = await GetContractStateAsync(this.client.BareJID, "legacy-contract-id");
+			Assert.IsNotNull(State);
+			Assert.AreEqual("creator@example.org", State.CreatorJid);
+			Assert.AreEqual(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, State.KeyAlgorithm);
+			CollectionAssert.AreEqual(SharedSecret, State.SharedSecret);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_19_SaveContractSharedSecretOnlyIfNewRespectsLegacyRuntimeValue()
+		{
+			byte[] ExistingSharedSecret = new byte[] { 3, 3, 3, 3 };
+			byte[] NewSharedSecret = new byte[] { 4, 4, 4, 4 };
+
+			await RuntimeSettings.SetAsync(this.contractsClient.ContractKeySettingsPrefix + "existing-contract-id",
+				EncodeLegacyContractSharedSecret(SymmetricCipherAlgorithms.Aes256, "creator@example.org", ExistingSharedSecret));
+
+			Assert.IsFalse(await InvokeSaveContractSharedSecretAsync(this.contractsClient, "existing-contract-id", this.client.BareJID,
+				NewSharedSecret, SymmetricCipherAlgorithms.AeadChaCha20Poly1305, true));
+
+			ContractSharedSecretState State = await GetContractStateAsync(this.client.BareJID, "existing-contract-id");
+			Assert.IsNotNull(State);
+			Assert.AreEqual("creator@example.org", State.CreatorJid);
+			Assert.AreEqual(SymmetricCipherAlgorithms.Aes256, State.KeyAlgorithm);
+			CollectionAssert.AreEqual(ExistingSharedSecret, State.SharedSecret);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_20_ExportKeysMigratesLegacyContractSecretAndUsesContractStateFormat()
+		{
+			byte[] PersistedSecret = new byte[] { 5, 4, 3, 2 };
+			byte[] LegacySecret = new byte[] { 2, 3, 4, 5 };
+
+			Assert.IsTrue(await InvokeSaveContractSharedSecretAsync(this.contractsClient, "persisted-contract-id", this.client.BareJID,
+				PersistedSecret, SymmetricCipherAlgorithms.Aes256, false));
+			await RuntimeSettings.SetAsync(this.contractsClient.ContractKeySettingsPrefix + "legacy-contract-id",
+				EncodeLegacyContractSharedSecret(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, "creator@example.org", LegacySecret));
+
+			string Xml = await this.contractsClient.ExportKeys();
+
+			Assert.IsTrue(Xml.Contains("<C ", StringComparison.Ordinal));
+			Assert.IsTrue(Xml.Contains("persisted-contract-id", StringComparison.Ordinal));
+			Assert.IsTrue(Xml.Contains("legacy-contract-id", StringComparison.Ordinal));
+			Assert.IsFalse(Xml.Contains("ContractState", StringComparison.Ordinal));
+
+			ContractSharedSecretState State = await GetContractStateAsync(this.client.BareJID, "legacy-contract-id");
+			Assert.IsNotNull(State);
+			Assert.AreEqual("creator@example.org", State.CreatorJid);
+			CollectionAssert.AreEqual(LegacySecret, State.SharedSecret);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_21_ImportKeysRoundTripWithContractStateRestoresSharedSecret()
+		{
+			byte[] SharedSecret = new byte[] { 7, 7, 7, 7, 7 };
+
+			Assert.IsTrue(await InvokeSaveContractSharedSecretAsync(this.contractsClient, "roundtrip-contract-id", this.client.BareJID,
+				SharedSecret, SymmetricCipherAlgorithms.Aes256, false));
+
+			string Xml = await this.contractsClient.ExportKeys();
+
+			await DeleteAllContractStatesAsync(this.client.BareJID);
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.ContractKeySettingsPrefix + "*", "*");
+
+			Assert.IsTrue(await this.contractsClient.ImportKeys(Xml));
+
+			Tuple<SymmetricCipherAlgorithms, string, byte[]> Secret = await InvokeTryLoadContractSharedSecretAsync(this.contractsClient, "roundtrip-contract-id");
+			Assert.IsNotNull(Secret);
+			Assert.AreEqual(SymmetricCipherAlgorithms.Aes256, Secret.Item1);
+			Assert.AreEqual(this.client.BareJID, Secret.Item2);
+			CollectionAssert.AreEqual(SharedSecret, Secret.Item3);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_22_ImportKeysBackwardCompatibilityRestoresLegacyContractSharedSecret()
+		{
+			byte[] SharedSecret = new byte[] { 6, 6, 6, 6 };
+			string Xml = "<LegalId xmlns=\"" + ContractsClient.NamespaceOnboarding + "\"><C n=\"legacy-import-contract-id\" v=\"" +
+				EncodeLegacyContractSharedSecret(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, "creator@example.org", SharedSecret) +
+				"\" /></LegalId>";
+
+			Assert.IsTrue(await this.contractsClient.ImportKeys(Xml));
+
+			ContractSharedSecretState State = await GetContractStateAsync(this.client.BareJID, "legacy-import-contract-id");
+			Assert.IsNotNull(State);
+			Assert.AreEqual("creator@example.org", State.CreatorJid);
+			Assert.AreEqual(SymmetricCipherAlgorithms.AeadChaCha20Poly1305, State.KeyAlgorithm);
+			CollectionAssert.AreEqual(SharedSecret, State.SharedSecret);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_23_MalformedLegacyContractSharedSecretIsIgnored()
+		{
+			await RuntimeSettings.SetAsync(this.contractsClient.ContractKeySettingsPrefix + "malformed-contract-id", "not|valid");
+
+			Assert.IsNull(await InvokeTryLoadContractSharedSecretAsync(this.contractsClient, "malformed-contract-id"));
+			Assert.IsNull(await GetContractStateAsync(this.client.BareJID, "malformed-contract-id"));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_24_ContractStateSharedSecretIsProtectedByCallStack()
+		{
+			FieldInfo ApprovedSources = typeof(ContractSharedSecretState).GetField("approvedSources", BindingFlags.Static | BindingFlags.NonPublic);
+			ApprovedSources.SetValue(null, null);
+
+			try
+			{
+				ContractSharedSecretState State = new ContractSharedSecretState()
+				{
+					ContractId = "protected-contract-id"
+				};
+
+				State.SharedSecret = new byte[] { 1, 2, 3 };
+				ContractSharedSecretState.SetAllowedSources(new CallStack.ICallStackCheck[]
+				{
+					new CallStack.ApproveType(typeof(ContractsClient))
+				});
+
+				Assert.ThrowsException<CallStack.UnauthorizedCallstackException>(() =>
+				{
+					byte[] Bin = State.SharedSecret;
+				});
+			}
+			finally
+			{
+				ApprovedSources.SetValue(null, null);
+			}
+		}
+
 		private static byte[] GetFirstLocalPublicKey(ContractsClient ContractsClient)
 		{
 			IE2eEndpoint[] Keys = GetLocalKeys(ContractsClient);
@@ -522,6 +687,18 @@ namespace Waher.Networking.XMPP.Test
 			return (await Database.Find<LegalIdentityState>(new FilterFieldEqualTo("BareJid", BareJid))).ToList();
 		}
 
+		private static async Task<ContractSharedSecretState> GetContractStateAsync(string BareJid, string ContractId)
+		{
+			return await Database.FindFirstIgnoreRest<ContractSharedSecretState>(new FilterAnd(
+				new FilterFieldEqualTo("BareJid", BareJid),
+				new FilterFieldEqualTo("ContractId", ContractId)));
+		}
+
+		private static async Task<List<ContractSharedSecretState>> GetContractStatesAsync(string BareJid)
+		{
+			return (await Database.Find<ContractSharedSecretState>(new FilterFieldEqualTo("BareJid", BareJid))).ToList();
+		}
+
 		private static async Task DeleteAllStatesAsync(string BareJid)
 		{
 			foreach (LegalIdentityState State in await GetStatesAsync(BareJid))
@@ -531,6 +708,17 @@ namespace Waher.Networking.XMPP.Test
 				if (!string.IsNullOrEmpty(State.LegalId))
 					Types.UnregisterSingleton(State, State.LegalId);
 			}
+		}
+
+		private static async Task DeleteAllContractStatesAsync(string BareJid)
+		{
+			foreach (ContractSharedSecretState State in await GetContractStatesAsync(BareJid))
+				await Database.Delete(State);
+		}
+
+		private static string EncodeLegacyContractSharedSecret(SymmetricCipherAlgorithms Algorithm, string CreatorJid, byte[] SharedSecret)
+		{
+			return Algorithm.ToString() + "|" + CreatorJid + "|" + Convert.ToBase64String(SharedSecret);
 		}
 
 		private static string ExtractExportedStateXml(string Xml, bool RemovePrivateStateAttributes, bool KeepRuntimeSettings)
@@ -591,6 +779,25 @@ namespace Waher.Networking.XMPP.Test
 		{
 			MethodInfo Method = typeof(ContractsClient).GetMethod("SetLegalIdentityKeySnapshotAsync", BindingFlags.Instance | BindingFlags.NonPublic);
 			Task<bool> Task = (Task<bool>)Method.Invoke(ContractsClient, new object[] { State, Endpoint });
+			return await Task;
+		}
+
+		private static async Task<bool> InvokeSaveContractSharedSecretAsync(ContractsClient ContractsClient, string ContractId,
+			string CreatorJid, byte[] SharedSecret, SymmetricCipherAlgorithms Algorithm, bool OnlyIfNew)
+		{
+			MethodInfo Method = typeof(ContractsClient).GetMethod("SaveContractSharedSecret", BindingFlags.Instance | BindingFlags.NonPublic, null,
+				new Type[] { typeof(string), typeof(string), typeof(byte[]), typeof(SymmetricCipherAlgorithms), typeof(bool) }, null);
+			Task<bool> Task = (Task<bool>)Method.Invoke(ContractsClient, new object[] { ContractId, CreatorJid, SharedSecret, Algorithm, OnlyIfNew });
+			return await Task;
+		}
+
+		private static async Task<Tuple<SymmetricCipherAlgorithms, string, byte[]>> InvokeTryLoadContractSharedSecretAsync(
+			ContractsClient ContractsClient, string ContractId)
+		{
+			MethodInfo Method = typeof(ContractsClient).GetMethod("TryLoadContractSharedSecret", BindingFlags.Instance | BindingFlags.NonPublic, null,
+				new Type[] { typeof(string) }, null);
+			Task<Tuple<SymmetricCipherAlgorithms, string, byte[]>> Task =
+				(Task<Tuple<SymmetricCipherAlgorithms, string, byte[]>>)Method.Invoke(ContractsClient, new object[] { ContractId });
 			return await Task;
 		}
 

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Waher.Networking.XMPP.Contracts;
+using Waher.Networking.XMPP.P2P;
+using Waher.Networking.XMPP.P2P.E2E;
+using Waher.Persistence;
+using Waher.Persistence.Files;
+using Waher.Persistence.Serialization;
+using Waher.Runtime.Collections;
+using Waher.Runtime.Inventory;
+using Waher.Runtime.Settings;
+
+namespace Waher.Networking.XMPP.Test
+{
+	[TestClass]
+	public class ContractsClientStateTests
+	{
+		private FilesProvider provider;
+		private XmppClient client;
+		private ContractsClient contractsClient;
+		private string dataFolder;
+
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext _)
+		{
+			Types.Initialize(
+				typeof(FilesProvider).Assembly,
+				typeof(ObjectSerializer).Assembly,
+				typeof(ContractsClientStateTests).Assembly,
+				typeof(ContractsClient).Assembly,
+				typeof(EndpointSecurity).Assembly,
+				typeof(RuntimeSettings).Assembly,
+				typeof(CaseInsensitiveString).Assembly);
+		}
+
+		[TestInitialize]
+		public async Task TestInitialize()
+		{
+			this.dataFolder = Path.Combine(Path.GetTempPath(), "ContractsClientStateTests", Guid.NewGuid().ToString("N"));
+			Directory.CreateDirectory(this.dataFolder);
+
+			this.provider = await FilesProvider.CreateAsync(this.dataFolder, "Default", 8192, 1000, 8192, Encoding.UTF8, 10000, true);
+			Database.Register(this.provider, false);
+
+			this.client = new XmppClient(new XmppCredentials()
+			{
+				Host = "example.org",
+				Port = 5222,
+				Account = "contracts.state.test",
+				Password = "test"
+			}, "en", typeof(ContractsClientStateTests).Assembly);
+
+			this.contractsClient = new ContractsClient(this.client, "legal.example.org");
+			Assert.IsTrue(await this.contractsClient.LoadKeys(true));
+		}
+
+		[TestCleanup]
+		public async Task TestCleanup()
+		{
+			if (this.client is not null)
+			{
+				await this.client.DisposeAsync();
+				this.client = null;
+			}
+
+			if (this.provider is not null)
+			{
+				Database.Register(new NullDatabaseProvider(), false);
+				await this.provider.DisposeAsync();
+				this.provider = null;
+			}
+
+			if (!string.IsNullOrEmpty(this.dataFolder) && Directory.Exists(this.dataFolder))
+				Directory.Delete(this.dataFolder, true);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_01_ExportKeysSkipsApprovedStatesWithoutMatchingLocalPrivateKey()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-1));
+			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
+
+			string Xml = await this.contractsClient.ExportKeys();
+
+			StringAssert.Contains(Xml, "matching-id");
+			Assert.IsFalse(Xml.Contains("stale-id", StringComparison.Ordinal));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_02_GetLatestApprovedLegalIdIgnoresNullAndStalePublicKeys()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-2));
+			await InsertStateAsync(this.client.BareJID, "null-key-id", IdentityState.Approved, null, DateTime.UtcNow.AddMinutes(-1));
+			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
+
+			string LatestApprovedLegalId = await this.contractsClient.GetLatestApprovedLegalId();
+			string LatestApprovedMatchingLegalId = await this.contractsClient.GetLatestApprovedLegalId(MatchingPublicKey);
+
+			Assert.AreEqual("matching-id", LatestApprovedLegalId);
+			Assert.AreEqual("matching-id", LatestApprovedMatchingLegalId);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_03_SignWithLatestApprovedIdUsesMatchingApprovedState()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-2));
+			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
+
+			using MemoryStream Data = new MemoryStream(Encoding.UTF8.GetBytes("contracts-client-state-test"));
+			byte[] Signature = await this.contractsClient.SignAsync(Data, SignWith.LatestApprovedId);
+
+			Assert.IsNotNull(Signature);
+			Assert.IsTrue(Signature.Length > 0);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_04_CanGenerateNewKeysReturnsTrueWhenActiveStatesHaveMatchingLocalKeys()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
+
+			Assert.IsTrue(await this.contractsClient.CanGenerateNewKeys());
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_05_CanGenerateNewKeysReturnsFalseWhenActiveStatesExistWithoutPersistedPrivateKeys()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
+
+			Assert.IsFalse(await this.contractsClient.CanGenerateNewKeys());
+		}
+
+		private static byte[] GetFirstLocalPublicKey(ContractsClient ContractsClient)
+		{
+			FieldInfo LocalKeysField = typeof(ContractsClient).GetField("localKeys", BindingFlags.Instance | BindingFlags.NonPublic);
+			EndpointSecurity LocalKeys = (EndpointSecurity)LocalKeysField.GetValue(ContractsClient);
+
+			PropertyInfo KeysProperty = typeof(EndpointSecurity).GetProperty("Keys", BindingFlags.Instance | BindingFlags.NonPublic);
+			IE2eEndpoint[] Keys = (IE2eEndpoint[])KeysProperty.GetValue(LocalKeys);
+
+			Assert.IsNotNull(Keys);
+			Assert.IsTrue(Keys.Length > 0);
+
+			return (byte[])Keys[0].PublicKey.Clone();
+		}
+
+		private static byte[] CreateStalePublicKey(byte[] MatchingPublicKey)
+		{
+			byte[] Result = (byte[])MatchingPublicKey.Clone();
+			Result[0] ^= 1;
+			return Result;
+		}
+
+		private static async Task InsertStateAsync(string BareJid, string LegalId, IdentityState State, byte[] PublicKey, DateTime Timestamp)
+		{
+			await Database.Insert(new LegalIdentityState()
+			{
+				BareJid = BareJid,
+				LegalId = LegalId,
+				PublicKey = PublicKey,
+				State = State,
+				Timestamp = Timestamp
+			});
+		}
+	}
+}

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -373,6 +373,74 @@ namespace Waher.Networking.XMPP.Test
 			Assert.IsFalse(Xml.Contains("malformed-id", StringComparison.Ordinal));
 		}
 
+		[TestMethod]
+		public async Task ContractsClient_State_Test_15_SnapshotUsesPrivateKeyThatMatchesEndpointPublicKeyAfterRotation()
+		{
+			IE2eEndpoint OriginalEndpoint = GetFirstLocalEndpoint(this.contractsClient);
+			byte[] OriginalPublicKey = (byte[])OriginalEndpoint.PublicKey.Clone();
+
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			byte[] RotatedRuntimePrivateKey = await GetRuntimePrivateKeyAsync(this.contractsClient, OriginalEndpoint.LocalName);
+			IE2eEndpoint RotatedRuntimeEndpoint = CreatePrivateEndpoint(OriginalEndpoint.LocalName, OriginalEndpoint.Namespace, RotatedRuntimePrivateKey);
+
+			try
+			{
+				Assert.IsFalse(AreEqual(OriginalPublicKey, RotatedRuntimeEndpoint.PublicKey));
+
+				LegalIdentityState State = new LegalIdentityState()
+				{
+					BareJid = this.client.BareJID,
+					LegalId = "snapshot-regression-id",
+					PublicKey = (byte[])OriginalPublicKey.Clone(),
+					State = IdentityState.Approved,
+					Timestamp = DateTime.UtcNow
+				};
+
+				Assert.IsTrue(await InvokeSetLegalIdentityKeySnapshotAsync(this.contractsClient, State, OriginalEndpoint));
+				Assert.IsTrue(State.HasPrivateKey);
+
+				IE2eEndpoint SnapshotEndpoint = CreatePrivateEndpoint(State.KeyName, State.KeyNamespace, State.PrivateKey);
+
+				try
+				{
+					CollectionAssert.AreEqual(OriginalPublicKey, State.PublicKey);
+					CollectionAssert.AreEqual(OriginalPublicKey, SnapshotEndpoint.PublicKey);
+				}
+				finally
+				{
+					SnapshotEndpoint.Dispose();
+				}
+			}
+			finally
+			{
+				RotatedRuntimeEndpoint.Dispose();
+			}
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_16_GenerateNewKeysRefreshesActiveKeysWhenSharedWithE2e()
+		{
+			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await this.contractsClient.EnableE2eEncryption(true, false);
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			byte[] RotatedPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			byte[] RotatedRuntimePrivateKey = await GetRuntimePrivateKeyAsync(this.contractsClient, "ed448");
+			IE2eEndpoint RotatedRuntimeEndpoint = CreatePrivateEndpoint("ed448", EndpointSecurity.IoTHarmonizationE2ECurrent, RotatedRuntimePrivateKey);
+
+			try
+			{
+				Assert.IsFalse(AreEqual(OriginalPublicKey, RotatedPublicKey));
+				CollectionAssert.AreEqual(RotatedRuntimeEndpoint.PublicKey, RotatedPublicKey);
+			}
+			finally
+			{
+				RotatedRuntimeEndpoint.Dispose();
+			}
+		}
+
 		private static byte[] GetFirstLocalPublicKey(ContractsClient ContractsClient)
 		{
 			IE2eEndpoint[] Keys = GetLocalKeys(ContractsClient);
@@ -381,6 +449,16 @@ namespace Waher.Networking.XMPP.Test
 			Assert.IsTrue(Keys.Length > 0);
 
 			return (byte[])Keys[0].PublicKey.Clone();
+		}
+
+		private static IE2eEndpoint GetFirstLocalEndpoint(ContractsClient ContractsClient)
+		{
+			IE2eEndpoint[] Keys = GetLocalKeys(ContractsClient);
+
+			Assert.IsNotNull(Keys);
+			Assert.IsTrue(Keys.Length > 0);
+
+			return Keys[0];
 		}
 
 		private static IE2eEndpoint[] GetLocalKeys(ContractsClient ContractsClient)
@@ -491,6 +569,27 @@ namespace Waher.Networking.XMPP.Test
 
 			Task Task = (Task)Method.Invoke(ContractsClient, new object[] { Identity, PublicKey });
 			await Task;
+		}
+
+		private static async Task<bool> InvokeSetLegalIdentityKeySnapshotAsync(ContractsClient ContractsClient, LegalIdentityState State, IE2eEndpoint Endpoint)
+		{
+			MethodInfo Method = typeof(ContractsClient).GetMethod("SetLegalIdentityKeySnapshotAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+			Task<bool> Task = (Task<bool>)Method.Invoke(ContractsClient, new object[] { State, Endpoint });
+			return await Task;
+		}
+
+		private static IE2eEndpoint CreatePrivateEndpoint(string KeyName, string KeyNamespace, byte[] PrivateKey)
+		{
+			Assert.IsTrue(EndpointSecurity.TryCreateEndpoint(KeyName, KeyNamespace, out IE2eEndpoint Template));
+
+			try
+			{
+				return Template.CreatePrivate(PrivateKey);
+			}
+			finally
+			{
+				Template.Dispose();
+			}
 		}
 
 		private static async Task InsertStateAsync(string BareJid, string LegalId, IdentityState State, byte[] PublicKey, DateTime Timestamp)

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Waher.Networking.XMPP.Contracts;
 using Waher.Networking.XMPP.P2P;
@@ -14,6 +17,7 @@ using Waher.Persistence.Serialization;
 using Waher.Runtime.Collections;
 using Waher.Runtime.Inventory;
 using Waher.Runtime.Settings;
+using CallStack = Waher.Security.CallStack;
 
 namespace Waher.Networking.XMPP.Test
 {
@@ -172,18 +176,220 @@ namespace Waher.Networking.XMPP.Test
 			Assert.IsTrue(Signature.Length > 0);
 		}
 
+		[TestMethod]
+		public async Task ContractsClient_State_Test_06_ImportKeysRoundTripWithStateSnapshotsRestoresApprovedIdentity()
+		{
+			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OriginalPublicKey, DateTime.UtcNow);
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("approved-id"));
+
+			string Xml = ExtractExportedStateXml(await this.contractsClient.ExportKeys(), RemovePrivateStateAttributes: false, KeepRuntimeSettings: false);
+
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+			await DeleteAllStatesAsync(this.client.BareJID);
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
+
+			Assert.IsTrue(await this.contractsClient.ImportKeys(Xml));
+			Assert.AreEqual("approved-id", await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId"));
+			Assert.IsTrue(await AwaitOrTimeout(this.contractsClient.HasPrivateKey("approved-id"), "HasPrivateKey"));
+
+			byte[] Signature = await AwaitOrTimeout(this.contractsClient.SignAsync(Encoding.UTF8.GetBytes("roundtrip"), SignWith.LatestApprovedId), "SignAsync");
+			Assert.IsTrue(Signature.Length > 0);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_07_ImportKeysBackwardCompatibilityBackfillsSnapshotFromRuntimeSettings()
+		{
+			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OriginalPublicKey, DateTime.UtcNow);
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("approved-id"));
+
+			string Xml = ExtractExportedStateXml(await this.contractsClient.ExportKeys(), RemovePrivateStateAttributes: true, KeepRuntimeSettings: true);
+
+			await DeleteAllStatesAsync(this.client.BareJID);
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
+
+			Assert.IsTrue(await this.contractsClient.ImportKeys(Xml));
+
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "approved-id");
+			Assert.IsNotNull(State);
+			Assert.IsFalse(State.HasPrivateKey);
+
+			Assert.IsTrue(await AwaitOrTimeout(this.contractsClient.HasPrivateKey("approved-id"), "HasPrivateKey"));
+
+			State = await GetStateAsync(this.client.BareJID, "approved-id");
+			Assert.IsTrue(State.HasPrivateKey);
+			Assert.IsFalse(string.IsNullOrEmpty(State.KeyName));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_08_SnapshotOnlyApprovedStateWorksAfterRuntimeKeysAreDeleted()
+		{
+			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OriginalPublicKey, DateTime.UtcNow);
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("approved-id"));
+
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
+			Assert.IsTrue(await this.contractsClient.LoadKeys(true));
+
+			byte[] NewPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			Assert.IsFalse(AreEqual(OriginalPublicKey, NewPublicKey));
+
+			Assert.AreEqual("approved-id", await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId"));
+			Assert.IsTrue(await AwaitOrTimeout(this.contractsClient.HasPrivateKey("approved-id"), "HasPrivateKey"));
+
+			byte[] Signature = await AwaitOrTimeout(this.contractsClient.SignAsync(Encoding.UTF8.GetBytes("snapshot-only"), SignWith.LatestApprovedId), "SignAsync");
+			Assert.IsTrue(Signature.Length > 0);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_09_UpdateSettingsReusesPreviewStateInsteadOfCreatingDuplicate()
+		{
+			byte[] PublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "preview-id", IdentityState.Created, PublicKey, DateTime.UtcNow.AddMinutes(-1));
+
+			LegalIdentity Identity = new LegalIdentity()
+			{
+				Id = "real-id",
+				State = IdentityState.Approved,
+				Created = DateTime.UtcNow.AddMinutes(-1),
+				Updated = DateTime.UtcNow
+			};
+
+			await InvokeUpdateSettingsAsync(this.contractsClient, Identity, PublicKey);
+
+			List<LegalIdentityState> States = await GetStatesAsync(this.client.BareJID);
+			Assert.AreEqual(1, States.Count);
+			Assert.AreEqual("real-id", (string)States[0].LegalId);
+			Assert.AreEqual(IdentityState.Approved, States[0].State);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_10_MismatchedSnapshotIsIgnored()
+		{
+			IE2eEndpoint[] Keys = GetLocalKeys(this.contractsClient);
+			Assert.IsTrue(Keys.Length >= 2);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, Keys[0].PublicKey, DateTime.UtcNow);
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "approved-id");
+			State.KeyName = Keys[1].LocalName;
+			State.KeyNamespace = Keys[1].Namespace;
+			State.PrivateKey = await GetRuntimePrivateKeyAsync(this.contractsClient, Keys[1].LocalName);
+			await Database.Update(State);
+
+			Assert.IsNull(await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId"));
+			Assert.IsFalse(await AwaitOrTimeout(this.contractsClient.HasPrivateKey("approved-id"), "HasPrivateKey"));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_11_NewerUnusableApprovedStateIsSkippedInFavorOfOlderUsableState()
+		{
+			IE2eEndpoint[] Keys = GetLocalKeys(this.contractsClient);
+			Assert.IsTrue(Keys.Length >= 2);
+
+			await InsertStateAsync(this.client.BareJID, "usable-id", IdentityState.Approved, Keys[0].PublicKey, DateTime.UtcNow.AddMinutes(-1));
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("usable-id"));
+
+			await InsertStateAsync(this.client.BareJID, "newer-unusable-id", IdentityState.Approved, Keys[0].PublicKey, DateTime.UtcNow);
+			LegalIdentityState Unusable = await GetStateAsync(this.client.BareJID, "newer-unusable-id");
+			Unusable.KeyName = Keys[1].LocalName;
+			Unusable.KeyNamespace = Keys[1].Namespace;
+			Unusable.PrivateKey = await GetRuntimePrivateKeyAsync(this.contractsClient, Keys[1].LocalName);
+			await Database.Update(Unusable);
+
+			Assert.AreEqual("usable-id", await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId"));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_12_GenerateNewKeysPreservesExistingSnapshot()
+		{
+			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OriginalPublicKey, DateTime.UtcNow);
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("approved-id"));
+
+			LegalIdentityState Before = await GetStateAsync(this.client.BareJID, "approved-id");
+			string PrivateKeyBefore = Convert.ToBase64String(Before.PrivateKey);
+			string KeyNameBefore = Before.KeyName;
+			string KeyNamespaceBefore = Before.KeyNamespace;
+
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			LegalIdentityState After = await GetStateAsync(this.client.BareJID, "approved-id");
+			Assert.AreEqual(KeyNameBefore, After.KeyName);
+			Assert.AreEqual(KeyNamespaceBefore, After.KeyNamespace);
+			Assert.AreEqual(PrivateKeyBefore, Convert.ToBase64String(After.PrivateKey));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_13_LegalIdentityStatePrivateKeyIsProtectedByCallStack()
+		{
+			FieldInfo ApprovedSources = typeof(LegalIdentityState).GetField("approvedSources", BindingFlags.Static | BindingFlags.NonPublic);
+			ApprovedSources.SetValue(null, null);
+
+			try
+			{
+				LegalIdentityState State = new LegalIdentityState()
+				{
+					LegalId = "protected-id"
+				};
+
+				State.PrivateKey = new byte[] { 1, 2, 3 };
+				LegalIdentityState.SetAllowedSources(new CallStack.ICallStackCheck[]
+				{
+					new CallStack.ApproveType(typeof(ContractsClient))
+				});
+
+				Assert.ThrowsException<CallStack.UnauthorizedCallstackException>(() =>
+				{
+					byte[] Bin = State.PrivateKey;
+				});
+			}
+			finally
+			{
+				ApprovedSources.SetValue(null, null);
+			}
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_14_ExportKeysSkipsMalformedSnapshotStates()
+		{
+			IE2eEndpoint[] Keys = GetLocalKeys(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "malformed-id", IdentityState.Approved, Keys[0].PublicKey, DateTime.UtcNow);
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "malformed-id");
+			State.KeyName = Keys[0].LocalName;
+			State.KeyNamespace = Keys[0].Namespace;
+			State.PrivateKey = new byte[] { 1, 2, 3, 4 };
+			await Database.Update(State);
+
+			string Xml = await this.contractsClient.ExportKeys();
+			Assert.IsFalse(Xml.Contains("malformed-id", StringComparison.Ordinal));
+		}
+
 		private static byte[] GetFirstLocalPublicKey(ContractsClient ContractsClient)
 		{
-			FieldInfo LocalKeysField = typeof(ContractsClient).GetField("localKeys", BindingFlags.Instance | BindingFlags.NonPublic);
-			EndpointSecurity LocalKeys = (EndpointSecurity)LocalKeysField.GetValue(ContractsClient);
-
-			PropertyInfo KeysProperty = typeof(EndpointSecurity).GetProperty("Keys", BindingFlags.Instance | BindingFlags.NonPublic);
-			IE2eEndpoint[] Keys = (IE2eEndpoint[])KeysProperty.GetValue(LocalKeys);
+			IE2eEndpoint[] Keys = GetLocalKeys(ContractsClient);
 
 			Assert.IsNotNull(Keys);
 			Assert.IsTrue(Keys.Length > 0);
 
 			return (byte[])Keys[0].PublicKey.Clone();
+		}
+
+		private static IE2eEndpoint[] GetLocalKeys(ContractsClient ContractsClient)
+		{
+			FieldInfo LocalKeysField = typeof(ContractsClient).GetField("localKeys", BindingFlags.Instance | BindingFlags.NonPublic);
+			EndpointSecurity LocalKeys = (EndpointSecurity)LocalKeysField.GetValue(ContractsClient);
+
+			PropertyInfo KeysProperty = typeof(EndpointSecurity).GetProperty("Keys", BindingFlags.Instance | BindingFlags.NonPublic);
+			return (IE2eEndpoint[])KeysProperty.GetValue(LocalKeys);
 		}
 
 		private static byte[] CreateStalePublicKey(byte[] MatchingPublicKey)
@@ -215,6 +421,76 @@ namespace Waher.Networking.XMPP.Test
 			return await Database.FindFirstIgnoreRest<LegalIdentityState>(new FilterAnd(
 				new FilterFieldEqualTo("BareJid", BareJid),
 				new FilterFieldEqualTo("LegalId", LegalId)));
+		}
+
+		private static async Task<List<LegalIdentityState>> GetStatesAsync(string BareJid)
+		{
+			return (await Database.Find<LegalIdentityState>(new FilterFieldEqualTo("BareJid", BareJid))).ToList();
+		}
+
+		private static async Task DeleteAllStatesAsync(string BareJid)
+		{
+			foreach (LegalIdentityState State in await GetStatesAsync(BareJid))
+			{
+				await Database.Delete(State);
+
+				if (!string.IsNullOrEmpty(State.LegalId))
+					Types.UnregisterSingleton(State, State.LegalId);
+			}
+		}
+
+		private static string ExtractExportedStateXml(string Xml, bool RemovePrivateStateAttributes, bool KeepRuntimeSettings)
+		{
+			XmlDocument Doc = new XmlDocument();
+			Doc.LoadXml(Xml);
+
+			List<XmlNode> ToRemove = new List<XmlNode>();
+
+			foreach (XmlNode N in Doc.DocumentElement.ChildNodes)
+			{
+				if (N is not XmlElement E)
+					continue;
+
+				if (E.LocalName == "State")
+				{
+					if (RemovePrivateStateAttributes)
+					{
+						E.RemoveAttribute("privateKey");
+						E.RemoveAttribute("keyName");
+						E.RemoveAttribute("keyNamespace");
+						E.RemoveAttribute("hasPrivateKey");
+					}
+
+					continue;
+				}
+
+				if (KeepRuntimeSettings && (E.LocalName == "S" || E.LocalName == "DT"))
+					continue;
+
+				ToRemove.Add(E);
+			}
+
+			foreach (XmlNode N in ToRemove)
+				Doc.DocumentElement.RemoveChild(N);
+
+			return Doc.OuterXml;
+		}
+
+		private static async Task<byte[]> GetRuntimePrivateKeyAsync(ContractsClient ContractsClient, string KeyName)
+		{
+			string Value = await RuntimeSettings.GetAsync(ContractsClient.KeySettingsPrefix + KeyName, string.Empty);
+			Assert.IsFalse(string.IsNullOrEmpty(Value));
+
+			return Convert.FromBase64String(Value);
+		}
+
+		private static async Task InvokeUpdateSettingsAsync(ContractsClient ContractsClient, LegalIdentity Identity, byte[] PublicKey)
+		{
+			MethodInfo Method = typeof(ContractsClient).GetMethod("UpdateSettings", BindingFlags.Instance | BindingFlags.NonPublic, null,
+				new Type[] { typeof(LegalIdentity), typeof(byte[]) }, null);
+
+			Task Task = (Task)Method.Invoke(ContractsClient, new object[] { Identity, PublicKey });
+			await Task;
 		}
 
 		private static async Task InsertStateAsync(string BareJid, string LegalId, IdentityState State, byte[] PublicKey, DateTime Timestamp)

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -421,12 +421,14 @@ namespace Waher.Networking.XMPP.Test
 		[TestMethod]
 		public async Task ContractsClient_State_Test_16_GenerateNewKeysRefreshesActiveKeysWhenSharedWithE2e()
 		{
-			byte[] OriginalPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			IE2eEndpoint OriginalEndpoint = GetLocalEndpoint(this.contractsClient, "ed448");
+			byte[] OriginalPublicKey = (byte[])OriginalEndpoint.PublicKey.Clone();
 
 			await this.contractsClient.EnableE2eEncryption(true, false);
 			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
 
-			byte[] RotatedPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			IE2eEndpoint RotatedEndpoint = GetLocalEndpoint(this.contractsClient, "ed448");
+			byte[] RotatedPublicKey = (byte[])RotatedEndpoint.PublicKey.Clone();
 			byte[] RotatedRuntimePrivateKey = await GetRuntimePrivateKeyAsync(this.contractsClient, "ed448");
 			IE2eEndpoint RotatedRuntimeEndpoint = CreatePrivateEndpoint("ed448", EndpointSecurity.IoTHarmonizationE2ECurrent, RotatedRuntimePrivateKey);
 
@@ -459,6 +461,20 @@ namespace Waher.Networking.XMPP.Test
 			Assert.IsTrue(Keys.Length > 0);
 
 			return Keys[0];
+		}
+
+		private static IE2eEndpoint GetLocalEndpoint(ContractsClient ContractsClient, string LocalName)
+		{
+			IE2eEndpoint[] Keys = GetLocalKeys(ContractsClient);
+
+			foreach (IE2eEndpoint Key in Keys)
+			{
+				if (Key.LocalName == LocalName)
+					return Key;
+			}
+
+			Assert.Fail("Local endpoint not found: " + LocalName);
+			return null;
 		}
 
 		private static IE2eEndpoint[] GetLocalKeys(ContractsClient ContractsClient)

--- a/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
+++ b/Networking/Waher.Networking.XMPP.Test/ContractsClientStateTests.cs
@@ -9,6 +9,7 @@ using Waher.Networking.XMPP.P2P;
 using Waher.Networking.XMPP.P2P.E2E;
 using Waher.Persistence;
 using Waher.Persistence.Files;
+using Waher.Persistence.Filters;
 using Waher.Persistence.Serialization;
 using Waher.Runtime.Collections;
 using Waher.Runtime.Inventory;
@@ -79,7 +80,78 @@ namespace Waher.Networking.XMPP.Test
 		}
 
 		[TestMethod]
-		public async Task ContractsClient_State_Test_01_ExportKeysSkipsApprovedStatesWithoutMatchingLocalPrivateKey()
+		public async Task ContractsClient_State_Test_01_LegacyApprovedStateBackfillsPrivateKeySnapshot()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
+
+			Assert.IsTrue(await this.contractsClient.HasPrivateKey("matching-id"));
+
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "matching-id");
+			Assert.IsNotNull(State);
+			Assert.IsTrue(State.HasPrivateKey);
+			Assert.IsFalse(string.IsNullOrEmpty(State.KeyName));
+			Assert.IsNotNull(State.PrivateKey);
+			CollectionAssert.AreEqual(MatchingPublicKey, State.PublicKey);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_02_GenerateNewKeysMigratesActiveStateAndSigningStillWorks()
+		{
+			byte[] OldPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OldPublicKey, DateTime.UtcNow);
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			byte[] NewPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+			Assert.IsFalse(AreEqual(OldPublicKey, NewPublicKey));
+
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "approved-id");
+			Assert.IsNotNull(State);
+			Assert.IsTrue(State.HasPrivateKey);
+			CollectionAssert.AreEqual(OldPublicKey, State.PublicKey);
+			Assert.AreEqual("approved-id", await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId"));
+			Assert.IsTrue(await AwaitOrTimeout(this.contractsClient.HasPrivateKey("approved-id"), "HasPrivateKey"));
+
+			byte[] Signature = await AwaitOrTimeout(this.contractsClient.SignAsync(Encoding.UTF8.GetBytes("contracts-client-state-test"), SignWith.LatestApprovedId), "SignAsync");
+			Assert.IsNotNull(Signature);
+			Assert.IsTrue(Signature.Length > 0);
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_03_GenerateNewKeysStillSucceedsWhenLegacySnapshotCannotBeBackfilled()
+		{
+			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
+			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			LegalIdentityState State = await GetStateAsync(this.client.BareJID, "approved-id");
+			Assert.IsNotNull(State);
+			Assert.IsFalse(State.HasPrivateKey);
+			Assert.IsFalse(await this.contractsClient.HasPrivateKey("approved-id"));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_04_ExportKeysIncludesPersistedApprovedStateAfterRotation()
+		{
+			byte[] OldPublicKey = GetFirstLocalPublicKey(this.contractsClient);
+
+			await InsertStateAsync(this.client.BareJID, "approved-id", IdentityState.Approved, OldPublicKey, DateTime.UtcNow);
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
+
+			string Xml = await this.contractsClient.ExportKeys();
+
+			StringAssert.Contains(Xml, "approved-id");
+			StringAssert.Contains(Xml, "privateKey=");
+			StringAssert.Contains(Xml, "keyName=");
+			StringAssert.Contains(Xml, Convert.ToBase64String(OldPublicKey));
+		}
+
+		[TestMethod]
+		public async Task ContractsClient_State_Test_05_LatestApprovedSelectionIgnoresStaleStatesWithoutSnapshots()
 		{
 			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
 			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
@@ -87,64 +159,17 @@ namespace Waher.Networking.XMPP.Test
 			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-1));
 			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
 
-			string Xml = await this.contractsClient.ExportKeys();
-
-			StringAssert.Contains(Xml, "matching-id");
-			Assert.IsFalse(Xml.Contains("stale-id", StringComparison.Ordinal));
-		}
-
-		[TestMethod]
-		public async Task ContractsClient_State_Test_02_GetLatestApprovedLegalIdIgnoresNullAndStalePublicKeys()
-		{
-			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
-			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
-
-			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-2));
-			await InsertStateAsync(this.client.BareJID, "null-key-id", IdentityState.Approved, null, DateTime.UtcNow.AddMinutes(-1));
-			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
-
-			string LatestApprovedLegalId = await this.contractsClient.GetLatestApprovedLegalId();
-			string LatestApprovedMatchingLegalId = await this.contractsClient.GetLatestApprovedLegalId(MatchingPublicKey);
+			string LatestApprovedLegalId = await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(), "GetLatestApprovedLegalId");
+			string LatestApprovedMatchingLegalId = await AwaitOrTimeout(this.contractsClient.GetLatestApprovedLegalId(MatchingPublicKey), "GetLatestApprovedLegalId(PublicKey)");
 
 			Assert.AreEqual("matching-id", LatestApprovedLegalId);
 			Assert.AreEqual("matching-id", LatestApprovedMatchingLegalId);
-		}
 
-		[TestMethod]
-		public async Task ContractsClient_State_Test_03_SignWithLatestApprovedIdUsesMatchingApprovedState()
-		{
-			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
-			byte[] StalePublicKey = CreateStalePublicKey(MatchingPublicKey);
+			await AwaitOrTimeout(this.contractsClient.GenerateNewKeys(), "GenerateNewKeys");
 
-			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow.AddMinutes(-2));
-			await InsertStateAsync(this.client.BareJID, "stale-id", IdentityState.Approved, StalePublicKey, DateTime.UtcNow);
-
-			using MemoryStream Data = new MemoryStream(Encoding.UTF8.GetBytes("contracts-client-state-test"));
-			byte[] Signature = await this.contractsClient.SignAsync(Data, SignWith.LatestApprovedId);
-
+			byte[] Signature = await AwaitOrTimeout(this.contractsClient.SignAsync(Encoding.UTF8.GetBytes("contracts-client-state-test"), SignWith.LatestApprovedId), "SignAsync");
 			Assert.IsNotNull(Signature);
 			Assert.IsTrue(Signature.Length > 0);
-		}
-
-		[TestMethod]
-		public async Task ContractsClient_State_Test_04_CanGenerateNewKeysReturnsTrueWhenActiveStatesHaveMatchingLocalKeys()
-		{
-			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
-
-			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
-
-			Assert.IsTrue(await this.contractsClient.CanGenerateNewKeys());
-		}
-
-		[TestMethod]
-		public async Task ContractsClient_State_Test_05_CanGenerateNewKeysReturnsFalseWhenActiveStatesExistWithoutPersistedPrivateKeys()
-		{
-			byte[] MatchingPublicKey = GetFirstLocalPublicKey(this.contractsClient);
-
-			await InsertStateAsync(this.client.BareJID, "matching-id", IdentityState.Approved, MatchingPublicKey, DateTime.UtcNow);
-			await RuntimeSettings.DeleteWhereKeyLikeAsync(this.contractsClient.KeySettingsPrefix + "*", "*");
-
-			Assert.IsFalse(await this.contractsClient.CanGenerateNewKeys());
 		}
 
 		private static byte[] GetFirstLocalPublicKey(ContractsClient ContractsClient)
@@ -168,6 +193,30 @@ namespace Waher.Networking.XMPP.Test
 			return Result;
 		}
 
+		private static bool AreEqual(byte[] A, byte[] B)
+		{
+			if (ReferenceEquals(A, B))
+				return true;
+
+			if (A is null || B is null || A.Length != B.Length)
+				return false;
+
+			for (int i = 0; i < A.Length; i++)
+			{
+				if (A[i] != B[i])
+					return false;
+			}
+
+			return true;
+		}
+
+		private static async Task<LegalIdentityState> GetStateAsync(string BareJid, string LegalId)
+		{
+			return await Database.FindFirstIgnoreRest<LegalIdentityState>(new FilterAnd(
+				new FilterFieldEqualTo("BareJid", BareJid),
+				new FilterFieldEqualTo("LegalId", LegalId)));
+		}
+
 		private static async Task InsertStateAsync(string BareJid, string LegalId, IdentityState State, byte[] PublicKey, DateTime Timestamp)
 		{
 			await Database.Insert(new LegalIdentityState()
@@ -178,6 +227,22 @@ namespace Waher.Networking.XMPP.Test
 				State = State,
 				Timestamp = Timestamp
 			});
+		}
+
+		private static async Task AwaitOrTimeout(Task OperationTask, string Operation)
+		{
+			if (await Task.WhenAny(OperationTask, Task.Delay(TimeSpan.FromSeconds(5))) != OperationTask)
+				Assert.Fail(Operation + " timed out.");
+
+			await OperationTask;
+		}
+
+		private static async Task<T> AwaitOrTimeout<T>(Task<T> OperationTask, string Operation)
+		{
+			if (await Task.WhenAny(OperationTask, Task.Delay(TimeSpan.FromSeconds(5))) != OperationTask)
+				Assert.Fail(Operation + " timed out.");
+
+			return await OperationTask;
 		}
 	}
 }

--- a/Networking/Waher.Networking.XMPP.Test/Waher.Networking.XMPP.Test.csproj
+++ b/Networking/Waher.Networking.XMPP.Test/Waher.Networking.XMPP.Test.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="..\..\Events\Waher.Events.Console\Waher.Events.Console.csproj" />
     <ProjectReference Include="..\..\Events\Waher.Events.XMPP\Waher.Events.XMPP.csproj" />
     <ProjectReference Include="..\..\Events\Waher.Events\Waher.Events.csproj" />
+    <ProjectReference Include="..\..\Persistence\Waher.Persistence.Files\Waher.Persistence.Files.csproj" />
+    <ProjectReference Include="..\..\Persistence\Waher.Persistence\Waher.Persistence.csproj" />
     <ProjectReference Include="..\..\Security\Waher.Security.PQC\Waher.Security.PQC.csproj" />
     <ProjectReference Include="..\..\Security\Waher.Security.SHA3\Waher.Security.SHA3.csproj" />
     <ProjectReference Include="..\Waher.Networking.HTTP\Waher.Networking.HTTP.csproj" />


### PR DESCRIPTION
## Summary

This PR fixes legal-identity key rotation so that the contracts client keeps three things consistent at all times:

- the client’s current active signing keys
- the in-memory key objects used for signing and E2E
- the persisted key snapshots stored per legal identity

The main problem was not only where keys were stored. It was that key rotation was not atomic across runtime settings, live in-memory state, and `LegalIdentityState`. That made it possible for old and new key material to be mixed.

This PR makes `ContractsClient` the owner of the active signing-key state, keeps legal-identity snapshots self-contained, and preserves backward compatibility for older persisted data through lazy migration.

## Problem

Before this change, the system could drift into inconsistent states during or after `GenerateNewKeys()`.

Two different sources were involved:

- `RuntimeSettings` stored the client’s current contract-signing keys
- `LegalIdentityState` stored identity state, but older rows could still depend on runtime keys being available to recover the private key

At the same time, the contracts client also reused in-memory `EndpointSecurity` instances for shared E2E/signing scenarios.

That created two classes of failure:

### 1. Stale active signing keys after rotation

When keys were shared with E2E, rotating runtime keys did not always replace the active in-memory signing keyset. The client could generate new keys in persistence, but still sign the next identity operation with an older in-memory key.

In practice, this could cause:

- preview identity applied with keypair A
- key rotation requested
- final identity still applied with public key A instead of a new keypair

### 2. Mixed public/private key snapshots

For persisted identity state, `PublicKey` could come from the endpoint instance being snapshotted, while `PrivateKey` could be recovered from runtime settings by `KeyName` only.

After rotation, that could produce invalid state such as:

- old public key
- new private key
- same `KeyName` (`ed448`), but not the same actual keypair

That made behaviors like these unreliable:

- `HasPrivateKey(...)`
- `GetLatestApprovedLegalId(...)`
- signing with `LatestApprovedId`
- export/import of key material
- preview-to-final identity transitions

## New Model

This PR establishes a clear separation of responsibility.

### `RuntimeSettings`
Holds the client’s **current active contract-signing keys**.

### `LegalIdentityState`
Holds the **persisted key snapshot for a specific legal identity**:

- `PrivateKey`
- `KeyName`
- `KeyNamespace`
- `PublicKey`

That means a legal identity no longer depends on the current runtime keyset still containing its original private key.

## Core Behavioral Changes

### `ContractsClient` now owns active signing-key state

The contracts client now treats loaded signing keys as internal state that it owns and activates explicitly.

Key loading is now conceptually split into two steps:

1. load/generate persisted key material
2. activate the live signing/E2E key context

This removes the old ambiguity where runtime settings, the `"E2E"` client tag, and `localKeys` could disagree.

### Shared E2E now mirrors signing keys instead of owning them

When E2E is configured to share the contracts client’s local keys:

- the active signing keyset is refreshed deterministically on load/rotation
- the shared `EndpointSecurity` instance is reused only if it actually matches the newly loaded keys
- otherwise it is replaced with a fresh instance built from the new active keys

This prevents key rotation from leaving signing on an old in-memory keyset.

### Identity snapshots are validated before reuse

When recovering a persisted private key from runtime settings for a legacy state, the framework now verifies that:

- the private key reconstructs a keypair
- the derived public key matches the `LegalIdentityState.PublicKey`

If it does not match, the runtime key is rejected for that identity snapshot.

This prevents old public keys and new private keys from being silently combined.

### Active-key mutations are serialized

Key-sensitive operations now run through a single internal mutation path so that these transitions happen safely:

- `LoadKeys(...)`
- `GenerateNewKeys()`
- `EnableE2eEncryption(...)`

This reduces the chance of transient mixed state during reload/rotation.

## Backward Compatibility

This change is intended to be backward-compatible for existing consumers and existing persisted data.

### Public API compatibility
No public `ContractsClient` API changes are required for consumers.

Existing flows such as:

- `LoadKeys(true)`
- `GenerateNewKeys()`
- `EnableE2eEncryption(true, false)`
- `EnableE2eEncryption(externalEndpoint, false)`

continue to work with the same call patterns.

### Persisted-data compatibility
Older `LegalIdentityState` rows that do not yet contain a private-key snapshot are still supported through lazy migration.

When such a state is used, the framework will:

1. try to find matching key material in `RuntimeSettings`
2. verify that the recovered key matches the persisted public key
3. persist the snapshot into `LegalIdentityState`

This means upgrades remain safe for existing installations.

If the original matching runtime key has already been rotated away, there is nothing safe to recover, and the state remains unusable until valid key material is imported.

## Security Tradeoff

This change improves correctness and durability across key rotation, but it also formalizes per-identity private key persistence.

The tradeoff is:

- historical identities remain usable after client key rotation
- more private key material is intentionally persisted in identity state

Mitigations remain in place:

- `LegalIdentityState.PrivateKey` is encrypted
- access is protected by call-stack restrictions

## Implementation Notes

Important behavior in this branch:

- active legal identities no longer lose signability just because current runtime keys were rotated
- key rotation updates both persisted current keys and the live active signing context
- shared E2E/signing mode no longer leaves stale in-memory key objects active after rotation
- malformed or mismatched identity snapshots are ignored instead of treated as valid
- preview identity state continues to be reused in-place rather than duplicated
- import/export continues to support persisted per-identity snapshots and legacy fallback behavior

## Tests

Coverage now includes:

1. Legacy state snapshot backfill
2. Rotation with preserved approved identities
3. Rotation when legacy keys can no longer be migrated
4. Export/import with persisted snapshots
5. Backward-compatible import of older exports
6. Snapshot-only identity use after runtime-key deletion
7. Preview-state deduplication
8. Rejection of mismatched or malformed snapshots
9. Latest-approved selection skipping unusable states
10. Snapshot preservation across rotation
11. Call-stack protection of persisted private keys
12. Snapshot validation after rotation
13. Shared-E2E rotation refreshing the active signing keyset

## Validation

Ran:

```powershell
dotnet test "c:\My Projects\IoTGateway\Networking\Waher.Networking.XMPP.Test\Waher.Networking.XMPP.Test.csproj" --filter "ContractsClient_State_Test" -v minimal
```

Result:

- 16 tests passed
- 0 failed