### PR TITLE
Encoding fix for null values

### DIFF
--- a/Content/Waher.Content/Multipart/WwwFormCodec.cs
+++ b/Content/Waher.Content/Multipart/WwwFormCodec.cs
@@ -219,7 +219,8 @@ namespace Waher.Content.Multipart
 
 					sb.Append(Uri.EscapeDataString(Pair.Key));
 					sb.Append('=');
-					sb.Append(Uri.EscapeDataString(Pair.Value));
+					if (!(Pair.Value is null))
+						sb.Append(Uri.EscapeDataString(Pair.Value));
 				}
 
 				if (Encoding is null)


### PR DESCRIPTION
Previously, when passing a dictionary with a key-value pair where the value is null, the encoding threw an exception. That was because EscapeDataString() could not handle null values. This fix makes it so it encodes a null value as ?valueA=&valueB=test, where valueA is null and valueB is "test". Since there is no standard way to encode null values, an encoder should either omit null values entirely or behave as this PR does. I chose not to omit them, since providing a null value might sometimes be different from omitting it entirely.